### PR TITLE
fix: exclude docs/ from vsix

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -2,6 +2,7 @@
 .vscode-test/**
 .github/**
 .claude/**
+docs/**
 src/**
 .gitignore
 .vscodeignore


### PR DESCRIPTION
The screenshot lives at docs/screenshot.png (358KB) and is only
referenced from README via an absolute raw.githubusercontent.com URL,
so shipping it inside the vsix is dead weight. Ignoring docs/** drops
the vsix from 372KB back to ~35KB, matching the pre-0.3.1 size.

Closes #14