### PR TITLE
docs: replace broken dynamic marketplace badges with static link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # LLM Slop Detector
 
-[![Marketplace version](https://vsmarketplacebadges.dev/version-short/thias-se.llm-slop-detector.svg?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
-[![Marketplace installs](https://vsmarketplacebadges.dev/installs-short/thias-se.llm-slop-detector.svg)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
-[![Marketplace rating](https://vsmarketplacebadges.dev/rating-short/thias-se.llm-slop-detector.svg)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
+[![Install on VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
 [![License: MIT](https://img.shields.io/github/license/mandakan/llm-slop-detector)](LICENSE)
 
 A VS Code extension that flags invisible Unicode, AI-style punctuation, and telltale LLM phrases in `markdown` and `plaintext` files.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # LLM Slop Detector
 
-[![Marketplace version](https://img.shields.io/visual-studio-marketplace/v/thias-se.llm-slop-detector?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
-[![Marketplace installs](https://img.shields.io/visual-studio-marketplace/i/thias-se.llm-slop-detector)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
-[![Marketplace rating](https://img.shields.io/visual-studio-marketplace/r/thias-se.llm-slop-detector)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
+[![Marketplace version](https://vsmarketplacebadges.dev/version-short/thias-se.llm-slop-detector.svg?label=marketplace)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
+[![Marketplace installs](https://vsmarketplacebadges.dev/installs-short/thias-se.llm-slop-detector.svg)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
+[![Marketplace rating](https://vsmarketplacebadges.dev/rating-short/thias-se.llm-slop-detector.svg)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
 [![License: MIT](https://img.shields.io/github/license/mandakan/llm-slop-detector)](LICENSE)
 
 A VS Code extension that flags invisible Unicode, AI-style punctuation, and telltale LLM phrases in `markdown` and `plaintext` files.


### PR DESCRIPTION
## Summary
- shields.io retired its `visual-studio-marketplace/*` endpoints, so the version, installs, and rating badges rendered as "retired badge"
- `vsmarketplacebadges.dev` now returns HTTP 500, and `badgen.net`'s installs/rating endpoints are also broken -- Microsoft's marketplace API is effectively closed to third-party badge hosts
- Drop the three dynamic badges and use one static "Install on VS Code Marketplace" shield that just links to the listing, plus the existing MIT badge

## Test plan
- [ ] Open the PR on GitHub and confirm the top of the README shows a clean "VS Code | Marketplace" badge and the MIT badge, with no broken images

🤖 Generated with [Claude Code](https://claude.com/claude-code)