### PR TITLE
ci: trigger downstream workflow steps and publish to marketplace

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: googleapis/release-please-action@v5
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
@@ -36,4 +37,9 @@ jobs:
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} *.vsix
+        if: ${{ steps.release.outputs.release_created }}
+
+      - env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce publish -p "$VSCE_PAT"
         if: ${{ steps.release.outputs.release_created }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,10 +117,10 @@ Managed by `.github/workflows/release-please.yml`. Do not bump `version` in `pac
 2. release-please opens (or updates) a **Release PR** titled "chore(main): release X.Y.Z" with the proposed version bump and CHANGELOG diff.
 3. When ready to ship, merge the Release PR.
 4. release-please creates the tag, the GitHub Release, and updates `CHANGELOG.md` on `main`.
-5. Same workflow then builds the vsix and uploads it to the release.
-6. Install locally: `code --install-extension llm-slop-detector-X.Y.Z.vsix`.
+5. Same workflow then builds the vsix, uploads it to the GitHub Release, and publishes it to the VS Code Marketplace under publisher `thias-se`.
+6. Install from Marketplace, or sideload: `code --install-extension llm-slop-detector-X.Y.Z.vsix`.
 
-Not published to the VS Code Marketplace. Distribution is vsix-via-GitHub-Releases.
+Marketplace publish uses an Azure DevOps PAT stored as the `VSCE_PAT` repo secret. release-please itself runs with a GitHub fine-grained PAT stored as `RELEASE_PLEASE_TOKEN` so that the Release-PR merge actually triggers downstream workflow steps (the default `GITHUB_TOKEN` does not, by design).
 
 ## Versions & targets
 


### PR DESCRIPTION
## Summary
- Pass a fine-grained PAT (`RELEASE_PLEASE_TOKEN`) to `release-please-action` so the Release-PR merge actually fires downstream workflow steps. Pushes authored by the default `GITHUB_TOKEN` are intentionally inert by GitHub's recursion guard, which is why prior releases needed a manual nudge.
- Add a `vsce publish -p $VSCE_PAT` step, gated on `steps.release.outputs.release_created`, so each release is pushed to the VS Code Marketplace under publisher \`thias-se\` in addition to the existing GitHub Release vsix upload.
- Update CLAUDE.md to reflect Marketplace publishing and document both secret names.

## Pre-merge checklist
- [ ] `RELEASE_PLEASE_TOKEN` repo secret is set (GitHub fine-grained PAT, scoped to this repo, Contents + PRs read/write, optionally Workflows read/write).
- [ ] `VSCE_PAT` repo secret is set (Azure DevOps PAT with **Marketplace -> Manage** on **all accessible organizations**; org-scoped or Acquire-only PATs will 401).

## Test plan
- [ ] Squash-merge this PR. Confirm release-please opens or updates a Release PR.
- [ ] Merge the next Release PR. Confirm a new workflow run starts on the resulting `main` push (this is what `RELEASE_PLEASE_TOKEN` unlocks).
- [ ] Confirm the run uploads the vsix to the GitHub Release and that `vsce publish` succeeds.
- [ ] Confirm the new version appears on the Marketplace under publisher `thias-se`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)