### PR TITLE
feat: skip code fences, link URLs, and ignore directives in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A VS Code extension that flags invisible Unicode, AI-style punctuation, and tell
 - Flags zero-width, BOM, non-breaking spaces, and other invisible Unicode that hides in text and wrecks diffs
 - Flags AI-style punctuation: em and en dashes, curly quotes, horizontal ellipsis, angle quotes
 - Configurable phrase rules: ~40 built-in core rules plus six opt-in packs (`academic`, `cliches`, `fiction`, `claudeisms`, `structural`, `security`) totalling 285+ curated regex patterns
+- Markdown-aware: skips fenced and inline code, link URLs, and YAML frontmatter so technical prose doesn't drown in false positives
+- Inline-ignore comments (`<!-- slop-disable -->`, `<!-- slop-disable-next-line -->`, `<!-- slop-disable-line -->`) for one-off exceptions
 - Per-workspace overrides via `.llmsloprc.json` and per-user overrides via settings
 - One-click quick fixes for deterministic character replacements, plus a "fix all" action
 - Status-bar slop counter for the active file, click to toggle
@@ -59,6 +61,50 @@ Right-aligned status bar item shows the slop count for the active `markdown` or 
 - `$(circle-slash) Slop off` when disabled
 
 Click toggles the detector. Hidden when the active editor is a different language.
+
+## Scope and ignores
+
+In `markdown` files, the scanner skips content where slop rules would only produce noise:
+
+- Fenced code blocks (` ``` ` and `~~~`) and inline code spans (`` `foo` ``)
+- Markdown link URLs (`[text](url)` -- the URL part) and autolinks (`<https://...>`)
+- YAML frontmatter at the top of the file (`---` ... `---` or `---` ... `...`)
+
+Link text, headings, and regular paragraphs are still scanned as before. Plain-text files are scanned in full; they have no markdown structure to skip.
+
+### Inline ignore comments
+
+For one-off exceptions in either `markdown` or `plaintext`, drop an HTML-style directive:
+
+```markdown
+<!-- slop-disable-next-line -->
+This line can delve as much as it wants.
+
+Text before <!-- slop-disable-line --> robust tapestry leverage -- all silenced.
+
+<!-- slop-disable -->
+Everything between these two markers is silenced,
+including multiple paragraphs.
+<!-- slop-enable -->
+```
+
+Three forms:
+
+- `<!-- slop-disable-line -->` -- silence the line the comment is on.
+- `<!-- slop-disable-next-line -->` -- silence the line after the comment.
+- `<!-- slop-disable -->` ... `<!-- slop-enable -->` -- silence everything between the two directives.
+
+By default a directive silences every rule on the covered range. To scope it to one rule, append a `phrase:<pattern>` or `char:<literal-or-codepoint>` spec:
+
+```markdown
+<!-- slop-disable-next-line phrase:\bdelve(s|d|ing)?\b -->
+This delve is fine but leverage still gets flagged.
+
+<!-- slop-disable-next-line char:U+2014 -->
+Em dashes allowed on this line -- but curly "quotes" still flag.
+```
+
+The `phrase:` value must match the rule's `pattern` field exactly (the literal regex string from the rule file, not the matched text). The `char:` value can be the literal character or a `U+XXXX` codepoint. Directives inside fenced or inline code are ignored, so README examples like this one don't accidentally silence the whole file.
 
 ## Rule packs
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,12 +50,17 @@ function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
   const diags: vscode.Diagnostic[] = [];
   const text = doc.getText();
 
+  const excluded = doc.languageId === 'markdown' ? computeMarkdownExclusions(text) : [];
+  const suppressions = computeSuppressions(text, excluded);
+
   // Characters.
   CHAR_REGEX.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = CHAR_REGEX.exec(text)) !== null) {
     const def = RULES.chars.get(m[0]);
     if (!def) continue;
+    if (offsetInRanges(m.index, excluded)) continue;
+    if (isSuppressed(m.index, suppressions, 'char', m[0])) continue;
     const start = doc.positionAt(m.index);
     const end = doc.positionAt(m.index + m[0].length);
     const d = new vscode.Diagnostic(new vscode.Range(start, end), charDiagnosticMessage(def), def.severity);
@@ -69,6 +74,8 @@ function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
     p.regex.lastIndex = 0;
     while ((m = p.regex.exec(text)) !== null) {
       if (m[0].length === 0) { p.regex.lastIndex++; continue; }
+      if (offsetInRanges(m.index, excluded)) continue;
+      if (isSuppressed(m.index, suppressions, 'phrase', m[0], p.pattern)) continue;
       const start = doc.positionAt(m.index);
       const end = doc.positionAt(m.index + m[0].length);
       const reasonBit = p.reason ? ` - ${p.reason}` : '';
@@ -84,6 +91,225 @@ function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
   }
 
   return diags;
+}
+
+// ---------------------------------------------------------------------------
+// Scope: markdown exclusions + inline ignore directives
+// ---------------------------------------------------------------------------
+
+type Range = [number, number];
+
+type Suppression = {
+  start: number;
+  end: number;
+  applies: (code: 'char' | 'phrase', matchText: string, rulePattern?: string) => boolean;
+};
+
+function mergeRanges(ranges: Range[]): Range[] {
+  if (ranges.length === 0) return ranges;
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: Range[] = [[ranges[0][0], ranges[0][1]]];
+  for (let i = 1; i < ranges.length; i++) {
+    const last = merged[merged.length - 1];
+    const curr = ranges[i];
+    if (curr[0] <= last[1]) {
+      last[1] = Math.max(last[1], curr[1]);
+    } else {
+      merged.push([curr[0], curr[1]]);
+    }
+  }
+  return merged;
+}
+
+function offsetInRanges(offset: number, ranges: Range[]): boolean {
+  let lo = 0, hi = ranges.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const [s, e] = ranges[mid];
+    if (offset < s) hi = mid - 1;
+    else if (offset >= e) lo = mid + 1;
+    else return true;
+  }
+  return false;
+}
+
+// Line-based scan for fenced code blocks and YAML frontmatter, plus regex for
+// inline code spans and link URLs. Good enough for the 95% case without
+// pulling in a CommonMark parser.
+function computeMarkdownExclusions(text: string): Range[] {
+  const ranges: Range[] = [];
+
+  let i = 0;
+  let lineIdx = 0;
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+  let fenceStart = 0;
+  let inFrontmatter = false;
+  let frontmatterStart = 0;
+
+  while (i <= text.length) {
+    const nl = text.indexOf('\n', i);
+    const lineEnd = nl === -1 ? text.length : nl;
+    const line = text.slice(i, lineEnd);
+    const nextLineStart = nl === -1 ? text.length : nl + 1;
+
+    if (!inFence) {
+      if (lineIdx === 0 && line === '---') {
+        inFrontmatter = true;
+        frontmatterStart = i;
+      } else if (inFrontmatter && (line === '---' || line === '...')) {
+        ranges.push([frontmatterStart, nextLineStart]);
+        inFrontmatter = false;
+      } else if (!inFrontmatter) {
+        const m = line.match(/^ {0,3}(`{3,}|~{3,})/);
+        if (m) {
+          inFence = true;
+          fenceChar = m[1][0];
+          fenceLen = m[1].length;
+          fenceStart = i;
+        }
+      }
+    } else {
+      const closer = new RegExp('^ {0,3}' + (fenceChar === '`' ? '`' : '~') + '{' + fenceLen + ',}\\s*$');
+      if (closer.test(line)) {
+        ranges.push([fenceStart, nextLineStart]);
+        inFence = false;
+      }
+    }
+
+    if (nl === -1) break;
+    lineIdx++;
+    i = nextLineStart;
+  }
+
+  if (inFence) ranges.push([fenceStart, text.length]);
+
+  // Inline code spans (single-backtick, same line).
+  let m: RegExpExecArray | null;
+  const inlineCodeRe = /`[^`\n]+`/g;
+  while ((m = inlineCodeRe.exec(text)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+
+  // Link URLs: the (...) part of [text](url). Exclude the URL, keep the text.
+  const linkRe = /\[[^\]\n]*\]\(([^)\n]+)\)/g;
+  while ((m = linkRe.exec(text)) !== null) {
+    const parenOpen = m.index + m[0].lastIndexOf('(');
+    const parenClose = m.index + m[0].length - 1;
+    ranges.push([parenOpen + 1, parenClose]);
+  }
+
+  // Autolinks: <https://...>.
+  const autolinkRe = /<https?:\/\/[^>\s]+>/gi;
+  while ((m = autolinkRe.exec(text)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+
+  return mergeRanges(ranges);
+}
+
+function parseSuppressionSpecs(raw: string): Suppression['applies'] {
+  const specs = raw.trim().split(/\s+/).filter(Boolean);
+  if (specs.length === 0) return () => true;
+
+  const phraseSpecs: string[] = [];
+  const charSpecs: string[] = [];
+  for (const s of specs) {
+    if (s.startsWith('phrase:')) phraseSpecs.push(s.slice('phrase:'.length));
+    else if (s.startsWith('char:')) charSpecs.push(s.slice('char:'.length));
+  }
+
+  return (code, matchText, rulePattern) => {
+    if (code === 'phrase') {
+      return phraseSpecs.some(p => rulePattern === p);
+    }
+    return charSpecs.some(c => {
+      if (/^u\+/i.test(c)) {
+        const cp = parseInt(c.slice(2), 16);
+        return !Number.isNaN(cp) && matchText.codePointAt(0) === cp;
+      }
+      return matchText === c;
+    });
+  };
+}
+
+// <!-- slop-disable [specs] --> ... <!-- slop-enable -->
+// <!-- slop-disable-next-line [specs] -->
+// <!-- slop-disable-line [specs] -->
+// Specs: phrase:<pattern> or char:<literal|U+XXXX>. Multiple specs AND across
+// kinds but OR within a kind. No specs = suppress everything.
+function computeSuppressions(text: string, excluded: Range[]): Suppression[] {
+  const directiveRe = /<!--\s*slop-(disable-next-line|disable-line|disable|enable)\b([^>]*?)-->/gi;
+  type Directive = {
+    kind: 'disable' | 'enable' | 'disable-next-line' | 'disable-line';
+    applies: Suppression['applies'];
+    start: number;
+    end: number;
+  };
+  const directives: Directive[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = directiveRe.exec(text)) !== null) {
+    if (offsetInRanges(m.index, excluded)) continue;
+    directives.push({
+      kind: m[1].toLowerCase() as Directive['kind'],
+      applies: parseSuppressionSpecs(m[2] || ''),
+      start: m.index,
+      end: m.index + m[0].length,
+    });
+  }
+
+  const result: Suppression[] = [];
+  let blockStart: number | null = null;
+  let blockApplies: Suppression['applies'] | null = null;
+
+  for (const d of directives) {
+    if (d.kind === 'disable') {
+      if (blockStart === null) {
+        blockStart = d.end;
+        blockApplies = d.applies;
+      }
+    } else if (d.kind === 'enable') {
+      if (blockStart !== null && blockApplies !== null) {
+        result.push({ start: blockStart, end: d.start, applies: blockApplies });
+        blockStart = null;
+        blockApplies = null;
+      }
+    } else if (d.kind === 'disable-line') {
+      const lineStart = text.lastIndexOf('\n', d.start - 1) + 1;
+      const nl = text.indexOf('\n', d.end);
+      const lineEnd = nl === -1 ? text.length : nl;
+      result.push({ start: lineStart, end: lineEnd, applies: d.applies });
+    } else if (d.kind === 'disable-next-line') {
+      const nl = text.indexOf('\n', d.end);
+      if (nl === -1) continue;
+      const nextLineStart = nl + 1;
+      const nextNl = text.indexOf('\n', nextLineStart);
+      const nextLineEnd = nextNl === -1 ? text.length : nextNl;
+      result.push({ start: nextLineStart, end: nextLineEnd, applies: d.applies });
+    }
+  }
+
+  if (blockStart !== null && blockApplies !== null) {
+    result.push({ start: blockStart, end: text.length, applies: blockApplies });
+  }
+
+  return result;
+}
+
+function isSuppressed(
+  offset: number,
+  suppressions: Suppression[],
+  code: 'char' | 'phrase',
+  matchText: string,
+  rulePattern?: string
+): boolean {
+  for (const s of suppressions) {
+    if (offset >= s.start && offset < s.end && s.applies(code, matchText, rulePattern)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #23. Part of #22.

## Summary

- Markdown-aware scope: fenced (` ``` `/`~~~`) and inline code, link URL targets, autolinks, and YAML frontmatter are skipped by both char and phrase rules. Link text, headings, and prose are still scanned.
- Inline-ignore HTML directives with optional per-rule scoping:
  - `<!-- slop-disable -->` ... `<!-- slop-enable -->` -- block range
  - `<!-- slop-disable-next-line -->` -- next line
  - `<!-- slop-disable-line -->` -- same line
  - Specs: `phrase:<rule-pattern>`, `char:<literal-or-U+XXXX>`; default (no specs) silences everything on the range
- Directives inside fenced / inline code ranges are ignored, so README examples can show directive syntax without silencing the rest of the file.
- README updated with a **Scope and ignores** section.

Implementation is pure string handling on top of the existing ` scanDocument ` pipeline: two offset filters (` offsetInRanges `, ` isSuppressed `) gate each match. No new dependencies, no parser. Line-based tokenisation for fences/frontmatter, single-pass regex for inline spans and directives.

## Test plan

- [ ] F5 in VS Code: open a markdown file with a fenced code block containing ` leverage ` -- no diagnostic on the fence contents, prose outside still flagged.
- [ ] Markdown link ` [click](https://example.com/foo--bar) ` -- link text scanned, em dash in URL not flagged.
- [ ] Autolink ` <https://example.com/delve> ` -- phrase inside not flagged.
- [ ] YAML frontmatter at top of file -- contents not flagged, body below still flagged.
- [ ] ` <!-- slop-disable-next-line --> ` on line N silences line N+1, leaves N+2 intact.
- [ ] ` <!-- slop-disable --> ` ... ` <!-- slop-enable --> ` silences everything between.
- [ ] ` <!-- slop-disable-next-line phrase:\\bdelve(s|d|ing)?\\b --> ` on a line with both ` delve ` and ` leverage ` -- only ` delve ` silenced.
- [ ] ` <!-- slop-disable-next-line char:U+2014 --> ` on a line with em dash and curly quote -- only em dash silenced.
- [ ] A directive shown inside a fenced code block (as README shows one) does not suppress anything outside the fence.

## Known simplifications

- Single-backtick inline code only. Double-backtick spans (` ``foo`bar`` `) aren't detected.
- Indented (4-space) code blocks not detected -- detection needs previous-line context and they're rare in technical docs. Can follow up if needed.
- Scope helpers live in ` src/extension.ts ` rather than a separate module. #24 (CLI) will want to share them; extracting to ` src/scope.ts ` is a clean follow-up, skipped here to keep the diff focused.