### PR TITLE
feat: ship CLI and pre-commit hook sharing the extension's rule engine

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: llm-slop
+  name: LLM Slop Detector
+  description: Flag LLM-style phrases and invisible Unicode in markdown and plaintext files.
+  entry: llm-slop
+  language: node
+  types_or: [markdown, plain-text]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,21 @@
 # LLM Slop Detector
 
-VS Code extension that flags invisible Unicode, AI-style punctuation, and LLM-telltale phrases in `markdown` and `plaintext` files.
+VS Code extension and CLI that flag invisible Unicode, AI-style punctuation, and LLM-telltale phrases in `markdown` and `plaintext` files.
 
-- Entry point: `src/extension.ts`
-- Rule loader: `src/rules.ts`
+- Extension entry: `src/extension.ts`
+- CLI entry: `src/cli.ts` (shipped as `llm-slop` via the `bin` field; same rule engine as the extension)
+- Pure core (no `vscode` import): `src/core/types.ts`, `src/core/rules.ts`, `src/core/scan.ts`. Shared by extension and CLI so they always produce identical findings.
+- VS Code adapter: `src/rules.ts` reads workspace config and delegates to `src/core/rules.ts`; `severityToVscode()` maps the pure `Severity` string union to `vscode.DiagnosticSeverity`
 - Built-in rule list: `builtin-rules.json` at repo root
-- No bundler: `tsc` outputs to `out/`
+- Pre-commit hook: `.pre-commit-hooks.yaml` at repo root
+- No bundler: `tsc` outputs to `out/`; `compile` also `chmod +x out/cli.js`
 
 ## Build & run
 
 - `npm run compile`: one-shot TypeScript build
 - `npm run watch`: incremental rebuild
 - `npm run package`: produces `llm-slop-detector-<version>.vsix` locally
+- `npm run slop -- <paths>`: run the CLI from source against files/dirs
 
 The fast dev loop is **F5 in VS Code**. Launches an Extension Development Host with the extension loaded (`.vscode/launch.json` starts the watcher via `preLaunchTask`). Edit, save, `Cmd+R` in the dev window.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Install on VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
 [![License: MIT](https://img.shields.io/github/license/mandakan/llm-slop-detector)](LICENSE)
 
-A VS Code extension that flags invisible Unicode, AI-style punctuation, and telltale LLM phrases in `markdown` and `plaintext` files.
+A VS Code extension and CLI that flag invisible Unicode, AI-style punctuation, and telltale LLM phrases in `markdown` and `plaintext` files. The CLI shares its rule engine with the editor, so local and CI findings stay in sync.
 
 ![LLM Slop Detector in action](https://raw.githubusercontent.com/mandakan/llm-slop-detector/main/docs/screenshot.png)
 
@@ -188,6 +188,72 @@ Patterns are JavaScript regex, case-insensitive. Use `\\b` for word boundaries.
 ```json
 "llmSlopDetector.phrases": ["\\byour own pet phrase\\b"],
 "llmSlopDetector.charReplacements": { "--": " - " }
+```
+
+## CLI
+
+The same rule engine ships as a CLI, useful for pre-commit hooks and CI. It produces identical findings to the extension for the same input and config.
+
+```bash
+llm-slop [options] <paths...>
+```
+
+Paths may be files or directories. Directories are walked recursively; files with extensions `.md`, `.markdown`, `.mdown`, `.txt`, or `.text` are scanned. `node_modules`, `out`, and dot-prefixed entries are skipped.
+
+Options:
+
+- `-f, --format <pretty|json|sarif>` -- output format (default `pretty`)
+- `--pack <name,...>` -- enable rule packs (comma-separated)
+- `--no-builtin` -- skip the built-in core rule list
+- `--config <path>` -- explicit `.llmsloprc.json` path (default: nearest ancestor of cwd)
+- `-s, --severity <level>` -- fail threshold: `error | warning | information | hint` (default `information`)
+- `-q, --quiet` -- suppress the summary line
+- `-h, --help` / `-v, --version`
+
+Exit code: `0` if no findings at or above the severity threshold, `1` if any, `2` on argument errors.
+
+### Running locally
+
+From a clone:
+
+```bash
+npm install
+npm run compile
+./out/cli.js README.md
+# or
+npm run slop -- README.md
+```
+
+From an installed copy of the extension (the VSIX bundles the CLI): link it globally.
+
+```bash
+cd ~/.vscode/extensions/thias-se.llm-slop-detector-*
+npm link   # optional -- exposes `llm-slop` on PATH
+```
+
+### Pre-commit hook
+
+`.pre-commit-hooks.yaml` ships at the repo root so you can wire it up via [pre-commit.com](https://pre-commit.com/):
+
+```yaml
+repos:
+  - repo: https://github.com/mandakan/llm-slop-detector
+    rev: v0.4.0
+    hooks:
+      - id: llm-slop
+```
+
+Pin to a released tag. The hook runs on staged `markdown` and `plaintext` files and fails the commit on any finding (override with `args: [--severity, error]` to only fail on errors).
+
+### GitHub Actions
+
+The SARIF output plugs into code-scanning:
+
+```yaml
+- run: npx llm-slop-detector --format=sarif . > slop.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: slop.sarif
 ```
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -41,6 +41,18 @@
     "onLanguage:plaintext"
   ],
   "main": "./out/extension.js",
+  "bin": {
+    "llm-slop": "./out/cli.js"
+  },
+  "files": [
+    "out/",
+    "builtin-rules.json",
+    "builtin-packs/",
+    "README.md",
+    "THIRD_PARTY_NOTICES.md",
+    "LICENSE",
+    ".pre-commit-hooks.yaml"
+  ],
   "contributes": {
     "configuration": {
       "title": "LLM Slop Detector",
@@ -118,9 +130,10 @@
     ]
   },
   "scripts": {
-    "compile": "tsc -p ./",
+    "compile": "tsc -p ./ && chmod +x out/cli.js",
     "watch": "tsc -watch -p ./",
-    "package": "npx --yes @vscode/vsce package"
+    "package": "npx --yes @vscode/vsce package",
+    "slop": "node ./out/cli.js"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/package.json
+++ b/package.json
@@ -44,15 +44,6 @@
   "bin": {
     "llm-slop": "./out/cli.js"
   },
-  "files": [
-    "out/",
-    "builtin-rules.json",
-    "builtin-packs/",
-    "README.md",
-    "THIRD_PARTY_NOTICES.md",
-    "LICENSE",
-    ".pre-commit-hooks.yaml"
-  ],
   "contributes": {
     "configuration": {
       "title": "LLM Slop Detector",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseArgs } from 'util';
+import { BUILTIN_PACKS, findLocalRulePathFromCwd, loadRules } from './core/rules';
+import { Finding, RuleSet, SEVERITY_RANK, Severity } from './core/types';
+import { Language, offsetToLineCol, scanText } from './core/scan';
+
+type Format = 'pretty' | 'json' | 'sarif';
+
+type CliOptions = {
+  paths: string[];
+  format: Format;
+  packs: string[];
+  useBuiltin: boolean;
+  configPath?: string;
+  severity: Severity;
+  quiet: boolean;
+};
+
+type FileReport = {
+  path: string;
+  findings: Finding[];
+};
+
+const SCAN_EXTENSIONS = new Map<string, Language>([
+  ['.md', 'markdown'],
+  ['.markdown', 'markdown'],
+  ['.mdown', 'markdown'],
+  ['.txt', 'plaintext'],
+  ['.text', 'plaintext'],
+]);
+
+const HELP = `llm-slop-detector [options] <paths...>
+
+Scan markdown and plaintext files for LLM-style phrases and invisible Unicode.
+
+Options:
+  -f, --format <pretty|json|sarif>  Output format (default: pretty)
+      --pack <name,...>             Enable built-in rule packs
+                                    (${BUILTIN_PACKS.join(', ')})
+      --no-builtin                  Skip the built-in core rule list
+      --config <path>               Path to a .llmsloprc.json file
+                                    (default: nearest ancestor of cwd)
+  -s, --severity <level>            Fail threshold: error | warning |
+                                    information | hint (default: information)
+  -q, --quiet                       Suppress the summary line
+  -h, --help                        Show this help
+  -v, --version                     Print version
+
+Exit code: 0 if no findings at or above the severity threshold, 1 otherwise.
+
+Examples:
+  llm-slop-detector README.md
+  llm-slop-detector --pack academic,cliches docs/
+  llm-slop-detector --format=json . > slop.json
+`;
+
+function parseCli(argv: string[]): CliOptions {
+  const parsed = parseArgs({
+    args: argv,
+    allowPositionals: true,
+    options: {
+      format: { type: 'string', short: 'f', default: 'pretty' },
+      pack: { type: 'string' },
+      'no-builtin': { type: 'boolean', default: false },
+      config: { type: 'string' },
+      severity: { type: 'string', short: 's', default: 'information' },
+      quiet: { type: 'boolean', short: 'q', default: false },
+      help: { type: 'boolean', short: 'h', default: false },
+      version: { type: 'boolean', short: 'v', default: false },
+    },
+    strict: true,
+  });
+
+  if (parsed.values.help) {
+    process.stdout.write(HELP);
+    process.exit(0);
+  }
+  if (parsed.values.version) {
+    process.stdout.write(readPackageVersion() + '\n');
+    process.exit(0);
+  }
+
+  const format = parsed.values.format as string;
+  if (format !== 'pretty' && format !== 'json' && format !== 'sarif') {
+    die(`unknown --format: ${format}`);
+  }
+
+  const severityRaw = parsed.values.severity as string;
+  if (!(severityRaw in SEVERITY_RANK)) {
+    die(`unknown --severity: ${severityRaw}`);
+  }
+
+  const packsRaw = parsed.values.pack as string | undefined;
+  const packs = packsRaw ? packsRaw.split(',').map(s => s.trim()).filter(Boolean) : [];
+  for (const p of packs) {
+    if (!(BUILTIN_PACKS as readonly string[]).includes(p)) {
+      die(`unknown pack: ${p}. Known: ${BUILTIN_PACKS.join(', ')}`);
+    }
+  }
+
+  if (parsed.positionals.length === 0) {
+    die('no paths given. Try --help.');
+  }
+
+  return {
+    paths: parsed.positionals,
+    format: format as Format,
+    packs,
+    useBuiltin: !parsed.values['no-builtin'],
+    configPath: parsed.values.config as string | undefined,
+    severity: severityRaw as Severity,
+    quiet: parsed.values.quiet as boolean,
+  };
+}
+
+function die(msg: string): never {
+  process.stderr.write(`llm-slop: ${msg}\n`);
+  process.exit(2);
+}
+
+function readPackageVersion(): string {
+  try {
+    const pkgPath = path.resolve(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+function extensionRoot(): string {
+  // Compiled CLI lives at out/cli.js; the extension root is its parent.
+  return path.resolve(__dirname, '..');
+}
+
+function collectFiles(paths: string[]): string[] {
+  const result: string[] = [];
+  for (const p of paths) {
+    const abs = path.resolve(p);
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(abs);
+    } catch {
+      process.stderr.write(`llm-slop: path not found: ${p}\n`);
+      continue;
+    }
+    if (stat.isFile()) {
+      result.push(abs);
+    } else if (stat.isDirectory()) {
+      walkDir(abs, result);
+    }
+  }
+  return result;
+}
+
+function walkDir(dir: string, out: string[]): void {
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (e.name.startsWith('.') || e.name === 'node_modules' || e.name === 'out') continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      walkDir(full, out);
+    } else if (e.isFile() && SCAN_EXTENSIONS.has(path.extname(e.name).toLowerCase())) {
+      out.push(full);
+    }
+  }
+}
+
+function languageFor(file: string): Language {
+  return SCAN_EXTENSIONS.get(path.extname(file).toLowerCase()) ?? 'plaintext';
+}
+
+function scanFile(file: string, rules: RuleSet): Finding[] {
+  const text = fs.readFileSync(file, 'utf8');
+  return scanText(text, rules, languageFor(file));
+}
+
+function shouldFail(reports: FileReport[], threshold: Severity): boolean {
+  const thresholdRank = SEVERITY_RANK[threshold];
+  for (const r of reports) {
+    for (const f of r.findings) {
+      if (SEVERITY_RANK[f.severity] <= thresholdRank) return true;
+    }
+  }
+  return false;
+}
+
+function formatPretty(reports: FileReport[], quiet: boolean): string {
+  const lines: string[] = [];
+  let total = 0;
+  const counts: Record<Severity, number> = { error: 0, warning: 0, information: 0, hint: 0 };
+  const sevTag: Record<Severity, string> = { error: 'error', warning: 'warn', information: 'info', hint: 'hint' };
+
+  for (const r of reports) {
+    if (r.findings.length === 0) continue;
+    const text = fs.readFileSync(r.path, 'utf8');
+    const rel = path.relative(process.cwd(), r.path) || r.path;
+    for (const f of r.findings) {
+      const { line, col } = offsetToLineCol(text, f.offset);
+      lines.push(`${rel}:${line}:${col}  ${sevTag[f.severity].padEnd(5)}  ${f.message}`);
+      counts[f.severity]++;
+      total++;
+    }
+  }
+
+  if (!quiet) {
+    if (total === 0) {
+      lines.push('No slop found.');
+    } else {
+      const parts: string[] = [];
+      for (const s of ['error', 'warning', 'information', 'hint'] as const) {
+        if (counts[s] > 0) parts.push(`${counts[s]} ${s}`);
+      }
+      lines.push('');
+      lines.push(`${total} finding${total === 1 ? '' : 's'} (${parts.join(', ')})`);
+    }
+  }
+
+  return lines.join('\n') + (lines.length > 0 ? '\n' : '');
+}
+
+function formatJson(reports: FileReport[]): string {
+  const out: unknown[] = [];
+  for (const r of reports) {
+    if (r.findings.length === 0) continue;
+    const text = fs.readFileSync(r.path, 'utf8');
+    const rel = path.relative(process.cwd(), r.path) || r.path;
+    for (const f of r.findings) {
+      const start = offsetToLineCol(text, f.offset);
+      const end = offsetToLineCol(text, f.offset + f.length);
+      out.push({
+        path: rel,
+        line: start.line,
+        col: start.col,
+        endLine: end.line,
+        endCol: end.col,
+        code: f.code,
+        severity: f.severity,
+        message: f.message,
+        source: f.source,
+        rulePattern: f.rulePattern,
+      });
+    }
+  }
+  return JSON.stringify(out, null, 2) + '\n';
+}
+
+function formatSarif(reports: FileReport[], version: string): string {
+  const sarifLevel: Record<Severity, 'error' | 'warning' | 'note'> = {
+    error: 'error',
+    warning: 'warning',
+    information: 'note',
+    hint: 'note',
+  };
+  const results: unknown[] = [];
+  for (const r of reports) {
+    if (r.findings.length === 0) continue;
+    const text = fs.readFileSync(r.path, 'utf8');
+    const rel = path.relative(process.cwd(), r.path) || r.path;
+    for (const f of r.findings) {
+      const start = offsetToLineCol(text, f.offset);
+      const end = offsetToLineCol(text, f.offset + f.length);
+      results.push({
+        ruleId: f.code === 'char' ? `char:${f.matchText}` : `phrase:${f.rulePattern ?? f.matchText}`,
+        level: sarifLevel[f.severity],
+        message: { text: f.message },
+        locations: [{
+          physicalLocation: {
+            artifactLocation: { uri: rel },
+            region: {
+              startLine: start.line,
+              startColumn: start.col,
+              endLine: end.line,
+              endColumn: end.col,
+            },
+          },
+        }],
+      });
+    }
+  }
+  const sarif = {
+    $schema: 'https://json.schemastore.org/sarif-2.1.0.json',
+    version: '2.1.0',
+    runs: [{
+      tool: {
+        driver: {
+          name: 'llm-slop-detector',
+          version,
+          informationUri: 'https://github.com/mandakan/llm-slop-detector',
+        },
+      },
+      results,
+    }],
+  };
+  return JSON.stringify(sarif, null, 2) + '\n';
+}
+
+function main(): void {
+  const opts = parseCli(process.argv.slice(2));
+
+  const localRulePaths: string[] = [];
+  if (opts.configPath) {
+    if (!fs.existsSync(opts.configPath)) die(`--config not found: ${opts.configPath}`);
+    localRulePaths.push(path.resolve(opts.configPath));
+  } else {
+    const found = findLocalRulePathFromCwd(process.cwd());
+    if (found) localRulePaths.push(found);
+  }
+
+  const rules = loadRules({
+    extensionRoot: extensionRoot(),
+    useBuiltin: opts.useBuiltin,
+    enabledPacks: opts.packs,
+    localRulePaths,
+    userPhrases: [],
+    charReplacements: {},
+  });
+
+  const files = collectFiles(opts.paths);
+  const reports: FileReport[] = files.map(f => ({ path: f, findings: scanFile(f, rules) }));
+
+  let output: string;
+  if (opts.format === 'json') output = formatJson(reports);
+  else if (opts.format === 'sarif') output = formatSarif(reports, readPackageVersion());
+  else output = formatPretty(reports, opts.quiet);
+
+  process.stdout.write(output);
+  process.exit(shouldFail(reports, opts.severity) ? 1 : 0);
+}
+
+main();

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -1,0 +1,214 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { CharRule, RuleSet, Severity } from './types';
+
+export const LOCAL_RULES_FILENAME = '.llmsloprc.json';
+
+export const BUILTIN_PACKS = ['academic', 'cliches', 'fiction', 'claudeisms', 'structural', 'security'] as const;
+export type BuiltinPack = typeof BUILTIN_PACKS[number];
+
+export type LoadOptions = {
+  extensionRoot: string;
+  useBuiltin: boolean;
+  enabledPacks: string[];
+  localRulePaths: string[];
+  userPhrases: string[];
+  charReplacements: Record<string, string>;
+};
+
+type RawCharRule = {
+  char?: unknown;
+  name?: unknown;
+  severity?: unknown;
+  replacement?: unknown;
+  suggestion?: unknown;
+};
+
+type RawPhraseRule = {
+  pattern?: unknown;
+  reason?: unknown;
+  severity?: unknown;
+};
+
+type RawList = {
+  name?: unknown;
+  version?: unknown;
+  description?: unknown;
+  chars?: unknown;
+  phrases?: unknown;
+};
+
+function parseSeverity(s: unknown, fallback: Severity): Severity {
+  switch (s) {
+    case 'error': return 'error';
+    case 'warning': return 'warning';
+    case 'information':
+    case 'info': return 'information';
+    case 'hint': return 'hint';
+    default: return fallback;
+  }
+}
+
+// Chars in the invisible/zero-width ranges are dangerous (hide in text,
+// break diffs, enable Trojan Source attacks); visible punctuation is merely suspicious.
+function defaultCharSeverity(char: string): Severity {
+  const code = char.codePointAt(0)!;
+  const invisible =
+    code === 0x00AD ||
+    code === 0x00A0 ||
+    code === 0x1160 ||
+    code === 0x180E ||
+    (code >= 0x200B && code <= 0x200F) ||
+    (code >= 0x202A && code <= 0x202E) ||
+    code === 0x202F ||
+    code === 0x2028 || code === 0x2029 ||
+    code === 0x2060 ||
+    (code >= 0x2066 && code <= 0x2069) ||
+    code === 0x3164 ||
+    code === 0xFEFF;
+  return invisible ? 'warning' : 'information';
+}
+
+function ingestList(raw: RawList, origin: string, target: RuleSet): void {
+  const name = typeof raw.name === 'string' ? raw.name : origin;
+  let charCount = 0;
+  let phraseCount = 0;
+
+  if (Array.isArray(raw.chars)) {
+    for (const c of raw.chars as RawCharRule[]) {
+      if (typeof c.char !== 'string' || c.char.length === 0) continue;
+      const charStr = c.char;
+      target.chars.set(charStr, {
+        char: charStr,
+        name: typeof c.name === 'string'
+          ? c.name
+          : `Unknown char (U+${charStr.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')})`,
+        severity: parseSeverity(c.severity, defaultCharSeverity(charStr)),
+        replacement: typeof c.replacement === 'string' ? c.replacement : undefined,
+        suggestion: typeof c.suggestion === 'string' ? c.suggestion : undefined,
+        source: name,
+      });
+      charCount++;
+    }
+  }
+
+  if (Array.isArray(raw.phrases)) {
+    for (const p of raw.phrases as RawPhraseRule[]) {
+      if (typeof p.pattern !== 'string' || p.pattern.length === 0) continue;
+      let regex: RegExp;
+      try {
+        regex = new RegExp(p.pattern, 'gi');
+      } catch (e) {
+        console.warn(`[LLM Slop] Invalid regex in ${origin}: ${p.pattern}`, e);
+        continue;
+      }
+      target.phrases.push({
+        pattern: p.pattern,
+        regex,
+        reason: typeof p.reason === 'string' ? p.reason : undefined,
+        severity: parseSeverity(p.severity, 'information'),
+        source: name,
+      });
+      phraseCount++;
+    }
+  }
+
+  target.sources.push({
+    name,
+    version: typeof raw.version === 'string' ? raw.version : undefined,
+    description: typeof raw.description === 'string' ? raw.description : undefined,
+    origin,
+    charCount,
+    phraseCount,
+  });
+}
+
+function readJsonFile(p: string): RawList | null {
+  try {
+    const text = fs.readFileSync(p, 'utf8');
+    const parsed = JSON.parse(text);
+    if (typeof parsed === 'object' && parsed !== null) return parsed as RawList;
+    console.warn(`[LLM Slop] ${p} is not a JSON object`);
+    return null;
+  } catch (e) {
+    console.warn(`[LLM Slop] Failed to read ${p}:`, e);
+    return null;
+  }
+}
+
+function buildCharRegex(chars: Map<string, CharRule>): RegExp {
+  if (chars.size === 0) return /(?!)/g;
+  const body = Array.from(chars.keys())
+    .map(c => '\\u{' + c.codePointAt(0)!.toString(16) + '}')
+    .join('');
+  return new RegExp('[' + body + ']', 'gu');
+}
+
+export function loadRules(opts: LoadOptions): RuleSet {
+  const rules: RuleSet = {
+    chars: new Map(),
+    phrases: [],
+    sources: [],
+    charRegex: /(?!)/g,
+  };
+
+  if (opts.useBuiltin) {
+    const builtinPath = path.join(opts.extensionRoot, 'builtin-rules.json');
+    const raw = readJsonFile(builtinPath);
+    if (raw) ingestList(raw, 'built-in', rules);
+  }
+
+  const allowed = new Set<string>(BUILTIN_PACKS);
+  for (const pack of opts.enabledPacks) {
+    if (!allowed.has(pack)) continue;
+    const packPath = path.join(opts.extensionRoot, 'builtin-packs', `${pack}.json`);
+    const raw = readJsonFile(packPath);
+    if (raw) ingestList(raw, `pack:${pack}`, rules);
+  }
+
+  for (const p of opts.localRulePaths) {
+    const raw = readJsonFile(p);
+    if (raw) ingestList(raw, p, rules);
+  }
+
+  if (opts.userPhrases.length > 0) {
+    ingestList(
+      { name: 'user settings', phrases: opts.userPhrases.map(pattern => ({ pattern })) },
+      'settings.json',
+      rules
+    );
+  }
+
+  for (const [char, replacement] of Object.entries(opts.charReplacements)) {
+    const existing = rules.chars.get(char);
+    if (existing) {
+      rules.chars.set(char, {
+        ...existing,
+        replacement,
+        source: `${existing.source} + settings`,
+      });
+    } else {
+      rules.chars.set(char, {
+        char,
+        name: `User-defined (U+${char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')})`,
+        severity: defaultCharSeverity(char),
+        replacement,
+        source: 'settings.json',
+      });
+    }
+  }
+
+  rules.charRegex = buildCharRegex(rules.chars);
+  return rules;
+}
+
+export function findLocalRulePathFromCwd(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(dir, LOCAL_RULES_FILENAME);
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -1,0 +1,287 @@
+import { CharRule, Finding, RuleSet } from './types';
+
+export type Language = 'markdown' | 'plaintext';
+
+type Range = [number, number];
+
+type Suppression = {
+  start: number;
+  end: number;
+  applies: (code: 'char' | 'phrase', matchText: string, rulePattern?: string) => boolean;
+};
+
+export function charDiagnosticMessage(def: CharRule): string {
+  const parts = [def.name];
+  if (def.replacement !== undefined) {
+    const shown =
+      def.replacement === '' ? 'delete' :
+      def.replacement === '\n' ? 'newline' :
+      def.replacement === ' ' ? 'regular space' :
+      JSON.stringify(def.replacement);
+    parts.push(`fix: ${shown}`);
+  } else if (def.suggestion) {
+    parts.push(def.suggestion);
+  }
+  return `${parts.join(' - ')} [${def.source}]`;
+}
+
+export function scanText(text: string, rules: RuleSet, language: Language): Finding[] {
+  const findings: Finding[] = [];
+  const excluded = language === 'markdown' ? computeMarkdownExclusions(text) : [];
+  const suppressions = computeSuppressions(text, excluded);
+
+  rules.charRegex.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = rules.charRegex.exec(text)) !== null) {
+    const def = rules.chars.get(m[0]);
+    if (!def) continue;
+    if (offsetInRanges(m.index, excluded)) continue;
+    if (isSuppressed(m.index, suppressions, 'char', m[0])) continue;
+    findings.push({
+      offset: m.index,
+      length: m[0].length,
+      matchText: m[0],
+      code: 'char',
+      severity: def.severity,
+      message: charDiagnosticMessage(def),
+      source: def.source,
+    });
+  }
+
+  for (const p of rules.phrases) {
+    p.regex.lastIndex = 0;
+    while ((m = p.regex.exec(text)) !== null) {
+      if (m[0].length === 0) { p.regex.lastIndex++; continue; }
+      if (offsetInRanges(m.index, excluded)) continue;
+      if (isSuppressed(m.index, suppressions, 'phrase', m[0], p.pattern)) continue;
+      const reasonBit = p.reason ? ` - ${p.reason}` : '';
+      findings.push({
+        offset: m.index,
+        length: m[0].length,
+        matchText: m[0],
+        code: 'phrase',
+        severity: p.severity,
+        message: `LLM-style phrase: "${m[0]}"${reasonBit} [${p.source}]`,
+        source: p.source,
+        rulePattern: p.pattern,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ---------------------------------------------------------------------------
+// Scope: markdown exclusions + inline ignore directives
+// ---------------------------------------------------------------------------
+
+function mergeRanges(ranges: Range[]): Range[] {
+  if (ranges.length === 0) return ranges;
+  ranges.sort((a, b) => a[0] - b[0]);
+  const merged: Range[] = [[ranges[0][0], ranges[0][1]]];
+  for (let i = 1; i < ranges.length; i++) {
+    const last = merged[merged.length - 1];
+    const curr = ranges[i];
+    if (curr[0] <= last[1]) {
+      last[1] = Math.max(last[1], curr[1]);
+    } else {
+      merged.push([curr[0], curr[1]]);
+    }
+  }
+  return merged;
+}
+
+function offsetInRanges(offset: number, ranges: Range[]): boolean {
+  let lo = 0, hi = ranges.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const [s, e] = ranges[mid];
+    if (offset < s) hi = mid - 1;
+    else if (offset >= e) lo = mid + 1;
+    else return true;
+  }
+  return false;
+}
+
+// Line-based scan for fenced code blocks and YAML frontmatter, plus regex for
+// inline code spans and link URLs. Good enough for the 95% case without
+// pulling in a CommonMark parser.
+function computeMarkdownExclusions(text: string): Range[] {
+  const ranges: Range[] = [];
+
+  let i = 0;
+  let lineIdx = 0;
+  let inFence = false;
+  let fenceChar = '';
+  let fenceLen = 0;
+  let fenceStart = 0;
+  let inFrontmatter = false;
+  let frontmatterStart = 0;
+
+  while (i <= text.length) {
+    const nl = text.indexOf('\n', i);
+    const lineEnd = nl === -1 ? text.length : nl;
+    const line = text.slice(i, lineEnd);
+    const nextLineStart = nl === -1 ? text.length : nl + 1;
+
+    if (!inFence) {
+      if (lineIdx === 0 && line === '---') {
+        inFrontmatter = true;
+        frontmatterStart = i;
+      } else if (inFrontmatter && (line === '---' || line === '...')) {
+        ranges.push([frontmatterStart, nextLineStart]);
+        inFrontmatter = false;
+      } else if (!inFrontmatter) {
+        const m = line.match(/^ {0,3}(`{3,}|~{3,})/);
+        if (m) {
+          inFence = true;
+          fenceChar = m[1][0];
+          fenceLen = m[1].length;
+          fenceStart = i;
+        }
+      }
+    } else {
+      const closer = new RegExp('^ {0,3}' + (fenceChar === '`' ? '`' : '~') + '{' + fenceLen + ',}\\s*$');
+      if (closer.test(line)) {
+        ranges.push([fenceStart, nextLineStart]);
+        inFence = false;
+      }
+    }
+
+    if (nl === -1) break;
+    lineIdx++;
+    i = nextLineStart;
+  }
+
+  if (inFence) ranges.push([fenceStart, text.length]);
+
+  let m: RegExpExecArray | null;
+  const inlineCodeRe = /`[^`\n]+`/g;
+  while ((m = inlineCodeRe.exec(text)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+
+  const linkRe = /\[[^\]\n]*\]\(([^)\n]+)\)/g;
+  while ((m = linkRe.exec(text)) !== null) {
+    const parenOpen = m.index + m[0].lastIndexOf('(');
+    const parenClose = m.index + m[0].length - 1;
+    ranges.push([parenOpen + 1, parenClose]);
+  }
+
+  const autolinkRe = /<https?:\/\/[^>\s]+>/gi;
+  while ((m = autolinkRe.exec(text)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+
+  return mergeRanges(ranges);
+}
+
+function parseSuppressionSpecs(raw: string): Suppression['applies'] {
+  const specs = raw.trim().split(/\s+/).filter(Boolean);
+  if (specs.length === 0) return () => true;
+
+  const phraseSpecs: string[] = [];
+  const charSpecs: string[] = [];
+  for (const s of specs) {
+    if (s.startsWith('phrase:')) phraseSpecs.push(s.slice('phrase:'.length));
+    else if (s.startsWith('char:')) charSpecs.push(s.slice('char:'.length));
+  }
+
+  return (code, matchText, rulePattern) => {
+    if (code === 'phrase') {
+      return phraseSpecs.some(p => rulePattern === p);
+    }
+    return charSpecs.some(c => {
+      if (/^u\+/i.test(c)) {
+        const cp = parseInt(c.slice(2), 16);
+        return !Number.isNaN(cp) && matchText.codePointAt(0) === cp;
+      }
+      return matchText === c;
+    });
+  };
+}
+
+function computeSuppressions(text: string, excluded: Range[]): Suppression[] {
+  const directiveRe = /<!--\s*slop-(disable-next-line|disable-line|disable|enable)\b([^>]*?)-->/gi;
+  type Directive = {
+    kind: 'disable' | 'enable' | 'disable-next-line' | 'disable-line';
+    applies: Suppression['applies'];
+    start: number;
+    end: number;
+  };
+  const directives: Directive[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = directiveRe.exec(text)) !== null) {
+    if (offsetInRanges(m.index, excluded)) continue;
+    directives.push({
+      kind: m[1].toLowerCase() as Directive['kind'],
+      applies: parseSuppressionSpecs(m[2] || ''),
+      start: m.index,
+      end: m.index + m[0].length,
+    });
+  }
+
+  const result: Suppression[] = [];
+  let blockStart: number | null = null;
+  let blockApplies: Suppression['applies'] | null = null;
+
+  for (const d of directives) {
+    if (d.kind === 'disable') {
+      if (blockStart === null) {
+        blockStart = d.end;
+        blockApplies = d.applies;
+      }
+    } else if (d.kind === 'enable') {
+      if (blockStart !== null && blockApplies !== null) {
+        result.push({ start: blockStart, end: d.start, applies: blockApplies });
+        blockStart = null;
+        blockApplies = null;
+      }
+    } else if (d.kind === 'disable-line') {
+      const lineStart = text.lastIndexOf('\n', d.start - 1) + 1;
+      const nl = text.indexOf('\n', d.end);
+      const lineEnd = nl === -1 ? text.length : nl;
+      result.push({ start: lineStart, end: lineEnd, applies: d.applies });
+    } else if (d.kind === 'disable-next-line') {
+      const nl = text.indexOf('\n', d.end);
+      if (nl === -1) continue;
+      const nextLineStart = nl + 1;
+      const nextNl = text.indexOf('\n', nextLineStart);
+      const nextLineEnd = nextNl === -1 ? text.length : nextNl;
+      result.push({ start: nextLineStart, end: nextLineEnd, applies: d.applies });
+    }
+  }
+
+  if (blockStart !== null && blockApplies !== null) {
+    result.push({ start: blockStart, end: text.length, applies: blockApplies });
+  }
+
+  return result;
+}
+
+function isSuppressed(
+  offset: number,
+  suppressions: Suppression[],
+  code: 'char' | 'phrase',
+  matchText: string,
+  rulePattern?: string
+): boolean {
+  for (const s of suppressions) {
+    if (offset >= s.start && offset < s.end && s.applies(code, matchText, rulePattern)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function offsetToLineCol(text: string, offset: number): { line: number; col: number } {
+  let line = 1;
+  let lastNl = -1;
+  for (let i = 0; i < offset && i < text.length; i++) {
+    if (text.charCodeAt(i) === 10) {
+      line++;
+      lastNl = i;
+    }
+  }
+  return { line, col: offset - lastNl };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,52 @@
+export type Severity = 'error' | 'warning' | 'information' | 'hint';
+
+export const SEVERITY_RANK: Record<Severity, number> = {
+  error: 0,
+  warning: 1,
+  information: 2,
+  hint: 3,
+};
+
+export type CharRule = {
+  char: string;
+  name: string;
+  severity: Severity;
+  replacement?: string;
+  suggestion?: string;
+  source: string;
+};
+
+export type PhraseRule = {
+  pattern: string;
+  regex: RegExp;
+  reason?: string;
+  severity: Severity;
+  source: string;
+};
+
+export type RuleSource = {
+  name: string;
+  version?: string;
+  description?: string;
+  origin: string;
+  charCount: number;
+  phraseCount: number;
+};
+
+export type RuleSet = {
+  chars: Map<string, CharRule>;
+  phrases: PhraseRule[];
+  sources: RuleSource[];
+  charRegex: RegExp;
+};
+
+export type Finding = {
+  offset: number;
+  length: number;
+  matchText: string;
+  code: 'char' | 'phrase';
+  severity: Severity;
+  message: string;
+  source: string;
+  rulePattern?: string;
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { CharRule, LOCAL_RULES_FILENAME, RuleSet, loadRules } from './rules';
+import { LOCAL_RULES_FILENAME, RuleSet, loadRules, severityToVscode } from './rules';
+import { Language, scanText } from './core/scan';
 
 const SOURCE = 'LLM Slop';
-const SUPPORTED_LANGS = new Set(['markdown', 'plaintext']);
+const SUPPORTED_LANGS = new Set<Language>(['markdown', 'plaintext']);
 const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [
   { language: 'markdown' },
   { language: 'plaintext' },
@@ -10,306 +11,24 @@ const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [
 
 // Module-level mutable rule state. Rebuilt on config change / rule-file change
 // and scans read through it.
-let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [] };
-let CHAR_REGEX: RegExp = /(?!)/g;
-
-function rebuildCharRegex() {
-  if (RULES.chars.size === 0) {
-    CHAR_REGEX = /(?!)/g;
-    return;
-  }
-  // \u{...} requires the u flag but accepts astral code points (tag chars,
-  // high-plane variation selectors). Map keys for astral chars are
-  // UTF-16 surrogate pairs, so Map.get(m[0]) still resolves correctly.
-  const body = Array.from(RULES.chars.keys())
-    .map(c => '\\u{' + c.codePointAt(0)!.toString(16) + '}')
-    .join('');
-  CHAR_REGEX = new RegExp('[' + body + ']', 'gu');
-}
+let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(?!)/g };
 
 function getReplacement(char: string): string | undefined {
   return RULES.chars.get(char)?.replacement;
 }
 
-function charDiagnosticMessage(def: CharRule): string {
-  const parts = [def.name];
-  if (def.replacement !== undefined) {
-    const shown =
-      def.replacement === '' ? 'delete' :
-      def.replacement === '\n' ? 'newline' :
-      def.replacement === ' ' ? 'regular space' :
-      JSON.stringify(def.replacement);
-    parts.push(`fix: ${shown}`);
-  } else if (def.suggestion) {
-    parts.push(def.suggestion);
-  }
-  return `${parts.join(' - ')} [${def.source}]`;
-}
-
 function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
-  const diags: vscode.Diagnostic[] = [];
-  const text = doc.getText();
-
-  const excluded = doc.languageId === 'markdown' ? computeMarkdownExclusions(text) : [];
-  const suppressions = computeSuppressions(text, excluded);
-
-  // Characters.
-  CHAR_REGEX.lastIndex = 0;
-  let m: RegExpExecArray | null;
-  while ((m = CHAR_REGEX.exec(text)) !== null) {
-    const def = RULES.chars.get(m[0]);
-    if (!def) continue;
-    if (offsetInRanges(m.index, excluded)) continue;
-    if (isSuppressed(m.index, suppressions, 'char', m[0])) continue;
-    const start = doc.positionAt(m.index);
-    const end = doc.positionAt(m.index + m[0].length);
-    const d = new vscode.Diagnostic(new vscode.Range(start, end), charDiagnosticMessage(def), def.severity);
+  const lang = doc.languageId as Language;
+  if (!SUPPORTED_LANGS.has(lang)) return [];
+  const findings = scanText(doc.getText(), RULES, lang);
+  return findings.map(f => {
+    const start = doc.positionAt(f.offset);
+    const end = doc.positionAt(f.offset + f.length);
+    const d = new vscode.Diagnostic(new vscode.Range(start, end), f.message, severityToVscode(f.severity));
     d.source = SOURCE;
-    d.code = 'char';
-    diags.push(d);
-  }
-
-  // Phrases.
-  for (const p of RULES.phrases) {
-    p.regex.lastIndex = 0;
-    while ((m = p.regex.exec(text)) !== null) {
-      if (m[0].length === 0) { p.regex.lastIndex++; continue; }
-      if (offsetInRanges(m.index, excluded)) continue;
-      if (isSuppressed(m.index, suppressions, 'phrase', m[0], p.pattern)) continue;
-      const start = doc.positionAt(m.index);
-      const end = doc.positionAt(m.index + m[0].length);
-      const reasonBit = p.reason ? ` - ${p.reason}` : '';
-      const d = new vscode.Diagnostic(
-        new vscode.Range(start, end),
-        `LLM-style phrase: "${m[0]}"${reasonBit} [${p.source}]`,
-        p.severity
-      );
-      d.source = SOURCE;
-      d.code = 'phrase';
-      diags.push(d);
-    }
-  }
-
-  return diags;
-}
-
-// ---------------------------------------------------------------------------
-// Scope: markdown exclusions + inline ignore directives
-// ---------------------------------------------------------------------------
-
-type Range = [number, number];
-
-type Suppression = {
-  start: number;
-  end: number;
-  applies: (code: 'char' | 'phrase', matchText: string, rulePattern?: string) => boolean;
-};
-
-function mergeRanges(ranges: Range[]): Range[] {
-  if (ranges.length === 0) return ranges;
-  ranges.sort((a, b) => a[0] - b[0]);
-  const merged: Range[] = [[ranges[0][0], ranges[0][1]]];
-  for (let i = 1; i < ranges.length; i++) {
-    const last = merged[merged.length - 1];
-    const curr = ranges[i];
-    if (curr[0] <= last[1]) {
-      last[1] = Math.max(last[1], curr[1]);
-    } else {
-      merged.push([curr[0], curr[1]]);
-    }
-  }
-  return merged;
-}
-
-function offsetInRanges(offset: number, ranges: Range[]): boolean {
-  let lo = 0, hi = ranges.length - 1;
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    const [s, e] = ranges[mid];
-    if (offset < s) hi = mid - 1;
-    else if (offset >= e) lo = mid + 1;
-    else return true;
-  }
-  return false;
-}
-
-// Line-based scan for fenced code blocks and YAML frontmatter, plus regex for
-// inline code spans and link URLs. Good enough for the 95% case without
-// pulling in a CommonMark parser.
-function computeMarkdownExclusions(text: string): Range[] {
-  const ranges: Range[] = [];
-
-  let i = 0;
-  let lineIdx = 0;
-  let inFence = false;
-  let fenceChar = '';
-  let fenceLen = 0;
-  let fenceStart = 0;
-  let inFrontmatter = false;
-  let frontmatterStart = 0;
-
-  while (i <= text.length) {
-    const nl = text.indexOf('\n', i);
-    const lineEnd = nl === -1 ? text.length : nl;
-    const line = text.slice(i, lineEnd);
-    const nextLineStart = nl === -1 ? text.length : nl + 1;
-
-    if (!inFence) {
-      if (lineIdx === 0 && line === '---') {
-        inFrontmatter = true;
-        frontmatterStart = i;
-      } else if (inFrontmatter && (line === '---' || line === '...')) {
-        ranges.push([frontmatterStart, nextLineStart]);
-        inFrontmatter = false;
-      } else if (!inFrontmatter) {
-        const m = line.match(/^ {0,3}(`{3,}|~{3,})/);
-        if (m) {
-          inFence = true;
-          fenceChar = m[1][0];
-          fenceLen = m[1].length;
-          fenceStart = i;
-        }
-      }
-    } else {
-      const closer = new RegExp('^ {0,3}' + (fenceChar === '`' ? '`' : '~') + '{' + fenceLen + ',}\\s*$');
-      if (closer.test(line)) {
-        ranges.push([fenceStart, nextLineStart]);
-        inFence = false;
-      }
-    }
-
-    if (nl === -1) break;
-    lineIdx++;
-    i = nextLineStart;
-  }
-
-  if (inFence) ranges.push([fenceStart, text.length]);
-
-  // Inline code spans (single-backtick, same line).
-  let m: RegExpExecArray | null;
-  const inlineCodeRe = /`[^`\n]+`/g;
-  while ((m = inlineCodeRe.exec(text)) !== null) {
-    ranges.push([m.index, m.index + m[0].length]);
-  }
-
-  // Link URLs: the (...) part of [text](url). Exclude the URL, keep the text.
-  const linkRe = /\[[^\]\n]*\]\(([^)\n]+)\)/g;
-  while ((m = linkRe.exec(text)) !== null) {
-    const parenOpen = m.index + m[0].lastIndexOf('(');
-    const parenClose = m.index + m[0].length - 1;
-    ranges.push([parenOpen + 1, parenClose]);
-  }
-
-  // Autolinks: <https://...>.
-  const autolinkRe = /<https?:\/\/[^>\s]+>/gi;
-  while ((m = autolinkRe.exec(text)) !== null) {
-    ranges.push([m.index, m.index + m[0].length]);
-  }
-
-  return mergeRanges(ranges);
-}
-
-function parseSuppressionSpecs(raw: string): Suppression['applies'] {
-  const specs = raw.trim().split(/\s+/).filter(Boolean);
-  if (specs.length === 0) return () => true;
-
-  const phraseSpecs: string[] = [];
-  const charSpecs: string[] = [];
-  for (const s of specs) {
-    if (s.startsWith('phrase:')) phraseSpecs.push(s.slice('phrase:'.length));
-    else if (s.startsWith('char:')) charSpecs.push(s.slice('char:'.length));
-  }
-
-  return (code, matchText, rulePattern) => {
-    if (code === 'phrase') {
-      return phraseSpecs.some(p => rulePattern === p);
-    }
-    return charSpecs.some(c => {
-      if (/^u\+/i.test(c)) {
-        const cp = parseInt(c.slice(2), 16);
-        return !Number.isNaN(cp) && matchText.codePointAt(0) === cp;
-      }
-      return matchText === c;
-    });
-  };
-}
-
-// <!-- slop-disable [specs] --> ... <!-- slop-enable -->
-// <!-- slop-disable-next-line [specs] -->
-// <!-- slop-disable-line [specs] -->
-// Specs: phrase:<pattern> or char:<literal|U+XXXX>. Multiple specs AND across
-// kinds but OR within a kind. No specs = suppress everything.
-function computeSuppressions(text: string, excluded: Range[]): Suppression[] {
-  const directiveRe = /<!--\s*slop-(disable-next-line|disable-line|disable|enable)\b([^>]*?)-->/gi;
-  type Directive = {
-    kind: 'disable' | 'enable' | 'disable-next-line' | 'disable-line';
-    applies: Suppression['applies'];
-    start: number;
-    end: number;
-  };
-  const directives: Directive[] = [];
-  let m: RegExpExecArray | null;
-  while ((m = directiveRe.exec(text)) !== null) {
-    if (offsetInRanges(m.index, excluded)) continue;
-    directives.push({
-      kind: m[1].toLowerCase() as Directive['kind'],
-      applies: parseSuppressionSpecs(m[2] || ''),
-      start: m.index,
-      end: m.index + m[0].length,
-    });
-  }
-
-  const result: Suppression[] = [];
-  let blockStart: number | null = null;
-  let blockApplies: Suppression['applies'] | null = null;
-
-  for (const d of directives) {
-    if (d.kind === 'disable') {
-      if (blockStart === null) {
-        blockStart = d.end;
-        blockApplies = d.applies;
-      }
-    } else if (d.kind === 'enable') {
-      if (blockStart !== null && blockApplies !== null) {
-        result.push({ start: blockStart, end: d.start, applies: blockApplies });
-        blockStart = null;
-        blockApplies = null;
-      }
-    } else if (d.kind === 'disable-line') {
-      const lineStart = text.lastIndexOf('\n', d.start - 1) + 1;
-      const nl = text.indexOf('\n', d.end);
-      const lineEnd = nl === -1 ? text.length : nl;
-      result.push({ start: lineStart, end: lineEnd, applies: d.applies });
-    } else if (d.kind === 'disable-next-line') {
-      const nl = text.indexOf('\n', d.end);
-      if (nl === -1) continue;
-      const nextLineStart = nl + 1;
-      const nextNl = text.indexOf('\n', nextLineStart);
-      const nextLineEnd = nextNl === -1 ? text.length : nextNl;
-      result.push({ start: nextLineStart, end: nextLineEnd, applies: d.applies });
-    }
-  }
-
-  if (blockStart !== null && blockApplies !== null) {
-    result.push({ start: blockStart, end: text.length, applies: blockApplies });
-  }
-
-  return result;
-}
-
-function isSuppressed(
-  offset: number,
-  suppressions: Suppression[],
-  code: 'char' | 'phrase',
-  matchText: string,
-  rulePattern?: string
-): boolean {
-  for (const s of suppressions) {
-    if (offset >= s.start && offset < s.end && s.applies(code, matchText, rulePattern)) {
-      return true;
-    }
-  }
-  return false;
+    d.code = f.code;
+    return d;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -383,7 +102,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const refresh = (doc: vscode.TextDocument) => {
     const enabled = vscode.workspace.getConfiguration('llmSlopDetector').get<boolean>('enabled', true);
-    if (!enabled || !SUPPORTED_LANGS.has(doc.languageId)) {
+    if (!enabled || !SUPPORTED_LANGS.has(doc.languageId as Language)) {
       collection.delete(doc.uri);
       return;
     }
@@ -396,7 +115,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const updateStatus = () => {
     const editor = vscode.window.activeTextEditor;
-    if (!editor || !SUPPORTED_LANGS.has(editor.document.languageId)) {
+    if (!editor || !SUPPORTED_LANGS.has(editor.document.languageId as Language)) {
       status.hide();
       return;
     }
@@ -429,7 +148,6 @@ export function activate(context: vscode.ExtensionContext) {
 
   const reloadRules = () => {
     RULES = loadRules(context.extensionUri);
-    rebuildCharRegex();
     vscode.workspace.textDocuments.forEach(refresh);
     updateStatus();
   };

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,165 +1,22 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
+import { BUILTIN_PACKS, LOCAL_RULES_FILENAME, loadRules as coreLoadRules } from './core/rules';
+import { RuleSet, Severity } from './core/types';
 
-export const LOCAL_RULES_FILENAME = '.llmsloprc.json';
+export { LOCAL_RULES_FILENAME, BUILTIN_PACKS };
+export type { RuleSet, CharRule, PhraseRule, RuleSource } from './core/types';
 
-export const BUILTIN_PACKS = ['academic', 'cliches', 'fiction', 'claudeisms', 'structural', 'security'] as const;
-export type BuiltinPack = typeof BUILTIN_PACKS[number];
-
-export type CharRule = {
-  char: string;
-  name: string;
-  severity: vscode.DiagnosticSeverity;
-  replacement?: string;
-  suggestion?: string;
-  source: string;
-};
-
-export type PhraseRule = {
-  pattern: string;
-  regex: RegExp;
-  reason?: string;
-  severity: vscode.DiagnosticSeverity;
-  source: string;
-};
-
-export type RuleSource = {
-  name: string;
-  version?: string;
-  description?: string;
-  origin: string;
-  charCount: number;
-  phraseCount: number;
-};
-
-export type RuleSet = {
-  chars: Map<string, CharRule>;
-  phrases: PhraseRule[];
-  sources: RuleSource[];
-};
-
-type RawCharRule = {
-  char?: unknown;
-  name?: unknown;
-  severity?: unknown;
-  replacement?: unknown;
-  suggestion?: unknown;
-};
-
-type RawPhraseRule = {
-  pattern?: unknown;
-  reason?: unknown;
-  severity?: unknown;
-};
-
-type RawList = {
-  name?: unknown;
-  version?: unknown;
-  description?: unknown;
-  chars?: unknown;
-  phrases?: unknown;
-};
-
-function parseSeverity(s: unknown, fallback: vscode.DiagnosticSeverity): vscode.DiagnosticSeverity {
+export function severityToVscode(s: Severity): vscode.DiagnosticSeverity {
   switch (s) {
     case 'error': return vscode.DiagnosticSeverity.Error;
     case 'warning': return vscode.DiagnosticSeverity.Warning;
-    case 'information':
-    case 'info': return vscode.DiagnosticSeverity.Information;
+    case 'information': return vscode.DiagnosticSeverity.Information;
     case 'hint': return vscode.DiagnosticSeverity.Hint;
-    default: return fallback;
   }
 }
 
-// Chars in the invisible/zero-width ranges are dangerous (hide in text,
-// break diffs, enable Trojan Source attacks); visible punctuation is merely suspicious.
-function defaultCharSeverity(char: string): vscode.DiagnosticSeverity {
-  const code = char.codePointAt(0)!;
-  const invisible =
-    code === 0x00AD ||
-    code === 0x00A0 ||
-    code === 0x1160 ||
-    code === 0x180E ||
-    (code >= 0x200B && code <= 0x200F) ||
-    (code >= 0x202A && code <= 0x202E) ||
-    code === 0x202F ||
-    code === 0x2028 || code === 0x2029 ||
-    code === 0x2060 ||
-    (code >= 0x2066 && code <= 0x2069) ||
-    code === 0x3164 ||
-    code === 0xFEFF;
-  return invisible ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Information;
-}
-
-function ingestList(raw: RawList, origin: string, target: RuleSet): void {
-  const name = typeof raw.name === 'string' ? raw.name : origin;
-  let charCount = 0;
-  let phraseCount = 0;
-
-  if (Array.isArray(raw.chars)) {
-    for (const c of raw.chars as RawCharRule[]) {
-      if (typeof c.char !== 'string' || c.char.length === 0) continue;
-      const charStr = c.char;
-      target.chars.set(charStr, {
-        char: charStr,
-        name: typeof c.name === 'string'
-          ? c.name
-          : `Unknown char (U+${charStr.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')})`,
-        severity: parseSeverity(c.severity, defaultCharSeverity(charStr)),
-        replacement: typeof c.replacement === 'string' ? c.replacement : undefined,
-        suggestion: typeof c.suggestion === 'string' ? c.suggestion : undefined,
-        source: name,
-      });
-      charCount++;
-    }
-  }
-
-  if (Array.isArray(raw.phrases)) {
-    for (const p of raw.phrases as RawPhraseRule[]) {
-      if (typeof p.pattern !== 'string' || p.pattern.length === 0) continue;
-      let regex: RegExp;
-      try {
-        regex = new RegExp(p.pattern, 'gi');
-      } catch (e) {
-        console.warn(`[LLM Slop] Invalid regex in ${origin}: ${p.pattern}`, e);
-        continue;
-      }
-      target.phrases.push({
-        pattern: p.pattern,
-        regex,
-        reason: typeof p.reason === 'string' ? p.reason : undefined,
-        severity: parseSeverity(p.severity, vscode.DiagnosticSeverity.Information),
-        source: name,
-      });
-      phraseCount++;
-    }
-  }
-
-  target.sources.push({
-    name,
-    version: typeof raw.version === 'string' ? raw.version : undefined,
-    description: typeof raw.description === 'string' ? raw.description : undefined,
-    origin,
-    charCount,
-    phraseCount,
-  });
-}
-
-function readJsonFile(p: string): RawList | null {
-  try {
-    const text = fs.readFileSync(p, 'utf8');
-    const parsed = JSON.parse(text);
-    if (typeof parsed === 'object' && parsed !== null) return parsed as RawList;
-    console.warn(`[LLM Slop] ${p} is not a JSON object`);
-    return null;
-  } catch (e) {
-    console.warn(`[LLM Slop] Failed to read ${p}:`, e);
-    return null;
-  }
-}
-
-export function getLocalRulePaths(): string[] {
+function getLocalRulePaths(): string[] {
   const paths: string[] = [];
   for (const folder of vscode.workspace.workspaceFolders ?? []) {
     const p = path.join(folder.uri.fsPath, LOCAL_RULES_FILENAME);
@@ -169,64 +26,13 @@ export function getLocalRulePaths(): string[] {
 }
 
 export function loadRules(extensionUri: vscode.Uri): RuleSet {
-  const rules: RuleSet = {
-    chars: new Map(),
-    phrases: [],
-    sources: [],
-  };
   const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
-
-  // 1. Built-in rules shipped with the extension.
-  if (cfg.get<boolean>('useBuiltinRules', true)) {
-    const builtinPath = vscode.Uri.joinPath(extensionUri, 'builtin-rules.json').fsPath;
-    const raw = readJsonFile(builtinPath);
-    if (raw) ingestList(raw, 'built-in', rules);
-  }
-
-  // 1b. Optional built-in packs the user opts into.
-  const enabledPacks = cfg.get<string[]>('enabledPacks', []);
-  const allowed = new Set<string>(BUILTIN_PACKS);
-  for (const pack of enabledPacks) {
-    if (!allowed.has(pack)) continue;
-    const packPath = vscode.Uri.joinPath(extensionUri, 'builtin-packs', `${pack}.json`).fsPath;
-    const raw = readJsonFile(packPath);
-    if (raw) ingestList(raw, `pack:${pack}`, rules);
-  }
-
-  // 2. Local workspace rule files (.llmsloprc.json at workspace root).
-  for (const p of getLocalRulePaths()) {
-    const raw = readJsonFile(p);
-    if (raw) ingestList(raw, p, rules);
-  }
-
-  // 3. User settings: simple additive layer for quick tweaks.
-  const userPhrases = cfg.get<string[]>('phrases', []);
-  if (userPhrases.length > 0) {
-    ingestList(
-      { name: 'user settings', phrases: userPhrases.map(pattern => ({ pattern })) },
-      'settings.json',
-      rules
-    );
-  }
-  const charOverrides = cfg.get<Record<string, string>>('charReplacements', {});
-  for (const [char, replacement] of Object.entries(charOverrides)) {
-    const existing = rules.chars.get(char);
-    if (existing) {
-      rules.chars.set(char, {
-        ...existing,
-        replacement,
-        source: `${existing.source} + settings`,
-      });
-    } else {
-      rules.chars.set(char, {
-        char,
-        name: `User-defined (U+${char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')})`,
-        severity: defaultCharSeverity(char),
-        replacement,
-        source: 'settings.json',
-      });
-    }
-  }
-
-  return rules;
+  return coreLoadRules({
+    extensionRoot: extensionUri.fsPath,
+    useBuiltin: cfg.get<boolean>('useBuiltinRules', true),
+    enabledPacks: cfg.get<string[]>('enabledPacks', []),
+    localRulePaths: getLocalRulePaths(),
+    userPhrases: cfg.get<string[]>('phrases', []),
+    charReplacements: cfg.get<Record<string, string>>('charReplacements', {}),
+  });
 }


### PR DESCRIPTION
Closes #24. Part of #22.

## Summary

- **` src/core/ ` (new, pure)**: ` types.ts `, ` rules.ts `, ` scan.ts ` -- no ` vscode ` import. Contains the rule loader, matcher, markdown scope, and ignore-directive logic extracted from the extension.
- **` src/cli.ts ` (new)**: ` #!/usr/bin/env node ` entry with pretty / JSON / SARIF output, directory walking (` .md `, ` .markdown `, ` .mdown `, ` .txt `, ` .text `), ` .llmsloprc.json ` discovery by walking up from cwd, ` --pack `, ` --no-builtin `, ` --config `, ` --severity `, ` --quiet `, ` --help `, ` --version `. Argument parsing via Node's ` util.parseArgs ` -- no dependencies added.
- **` src/rules.ts `**: now a thin VS Code adapter that reads workspace config and delegates to ` core/rules `. Adds ` severityToVscode() ` mapping the pure ` Severity ` string union to ` vscode.DiagnosticSeverity `.
- **` src/extension.ts `**: uses ` core/scan.scanText ` and maps ` Finding[] ` -> ` vscode.Diagnostic[] `. No behaviour change to users.
- **` .pre-commit-hooks.yaml `**: ships at repo root so users can pin the hook by tag.
- **` package.json `**: ` bin: { \"llm-slop\": \"./out/cli.js\" } `, ` files ` manifest for npm publish, ` compile ` now chmod +x's the CLI, new ` slop ` npm script for local runs.
- **README / CLAUDE.md**: document the CLI, pre-commit wiring, SARIF + GitHub Actions recipe, new architecture.

Extension and CLI produce identical findings by construction -- they call the same ` scanText ` with the same ` RuleSet `.

## CLI quick smoke (run locally)

` ` `bash
npm install && npm run compile
./out/cli.js README.md                          # pretty, exit 1
./out/cli.js README.md --severity error         # exit 0 (no errors)
./out/cli.js README.md --format=json | jq .     # structured
./out/cli.js README.md --format=sarif | jq .    # SARIF 2.1.0
./out/cli.js --pack structural docs/            # directory walk + pack
./out/cli.js --no-builtin README.md -q          # empty output
./out/cli.js --pack nonsense README.md          # exit 2, clean error
./out/cli.js                                    # exit 2, 'no paths given'
` ` `

## Test plan

- [ ] F5 in VS Code: existing markdown/plaintext flows unchanged (same findings as before the refactor).
- [ ] ` npm run compile ` produces an executable ` out/cli.js `.
- [ ] ` ./out/cli.js README.md ` matches what the extension shows for README.md.
- [ ] JSON output round-trips through ` jq ` / ` JSON.parse `.
- [ ] SARIF output validates (` jq . `, or paste into the SARIF validator).
- [ ] Directory walking skips ` node_modules `, ` out `, dot-prefixed entries.
- [ ] ` .llmsloprc.json ` at repo root is picked up automatically by CLI when run from a subdir.
- [ ] Exit codes: 0 clean, 1 findings at/above threshold, 2 on argument errors.
- [ ] ` pre-commit try-repo . ` against this branch succeeds.

## Known deferrals

- **No ` npm publish ` automation yet.** The package is ready for it (` bin `, ` files `, shebang, chmod step), but release-please is currently configured for VSIX only. Adding ` npm publish ` to the release workflow is a small follow-up once you're comfortable with the CLI's surface area.
- **` --fix ` / auto-fix mode not included.** Overlaps with the 'phrase quick fixes don't exist' gap from #22.
- **No ` .slopignore `.** File-glob ignores are tracked separately in #22.
- **Custom severity overrides** (` phrase:<pat>=hint `) deferred -- they're listed in #22 as their own gap.