### PR TITLE
feat: opt-in scanning of code comments and docstrings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ VS Code extension and CLI that flag invisible Unicode, AI-style punctuation, and
 
 - Extension entry: `src/extension.ts`
 - CLI entry: `src/cli.ts` (shipped as `llm-slop` via the `bin` field; same rule engine as the extension)
-- Pure core (no `vscode` import): `src/core/types.ts`, `src/core/rules.ts`, `src/core/scan.ts`. Shared by extension and CLI so they always produce identical findings.
+- Pure core (no `vscode` import): `src/core/types.ts`, `src/core/rules.ts`, `src/core/scan.ts`, `src/core/comments.ts`. Shared by extension and CLI so they always produce identical findings.
 - VS Code adapter: `src/rules.ts` reads workspace config and delegates to `src/core/rules.ts`; `severityToVscode()` maps the pure `Severity` string union to `vscode.DiagnosticSeverity`
 - Built-in rule list: `builtin-rules.json` at repo root
 - Pre-commit hook: `.pre-commit-hooks.yaml` at repo root

--- a/README.md
+++ b/README.md
@@ -106,6 +106,36 @@ Em dashes allowed on this line -- but curly "quotes" still flag.
 
 The `phrase:` value must match the rule's `pattern` field exactly (the literal regex string from the rule file, not the matched text). The `char:` value can be the literal character or a `U+XXXX` codepoint. Directives inside fenced or inline code are ignored, so README examples like this one don't accidentally silence the whole file.
 
+## Source code comments (opt-in)
+
+LLM slop frequently turns up in JSDoc, Python docstrings, Rust `///` blocks, and `//` comments. Turn on `llmSlopDetector.scanCodeComments` to scan those ranges too:
+
+```json
+"llmSlopDetector.scanCodeComments": true,
+"llmSlopDetector.codeCommentLanguages": [
+  "typescript", "javascript", "python", "rust", "go"
+]
+```
+
+Only comments and docstrings are scanned -- identifiers, string literals, and regular code are ignored. Supported language IDs: `typescript`, `javascript`, `typescriptreact`, `javascriptreact`, `python`, `rust`, `go`, `java`, `csharp`, `cpp`, `c`, `ruby`, `php`, `shellscript`, `swift`, `kotlin`, `scala`, `dart`, `perl`, `r`, `yaml`. Unknown IDs are silently ignored.
+
+### Known limitations
+
+Comment detection is lexical, not AST-based. This means:
+
+- **Python triple-quoted strings are scanned whether they are docstrings or data.** ` x = """some data with delve""" ` will flag. If that matters, put the data on the same line as an inline ignore directive, or switch to a regular string.
+- Regex literals in JavaScript (`/foo/`) aren't specially recognised; odd edge cases like `/** @regex /x/ */` can misparse. File an issue if you hit a real false positive.
+- Indented code blocks in Markdown (four-space) are still scanned -- use fenced blocks instead.
+
+If a comment contains a legitimate flagged word, use an inline ignore directive as usual:
+
+```ts
+/**
+ * <!-- slop-disable-next-line phrase:\bdelve(s|d|ing)?\b -->
+ * We intentionally delve into the cache layout here because...
+ */
+```
+
 ## Rule packs
 
 The core list is deliberately conservative: ~40 phrase rules covering the buzzwords everyone agrees on (`delve`, `leverage`, `seamless`, `paradigm shift`, etc.). For more coverage, opt into one or more packs via `llmSlopDetector.enabledPacks`:
@@ -207,6 +237,7 @@ Options:
 - `--no-builtin` -- skip the built-in core rule list
 - `--config <path>` -- explicit `.llmsloprc.json` path (default: nearest ancestor of cwd)
 - `-s, --severity <level>` -- fail threshold: `error | warning | information | hint` (default `information`)
+- `--scan-comments` -- also scan comments and docstrings in source code files (`.ts`, `.py`, `.rs`, etc). Off by default.
 - `-q, --quiet` -- suppress the summary line
 - `-h, --help` / `-v, --version`
 
@@ -244,6 +275,14 @@ repos:
 ```
 
 Pin to a released tag. The hook runs on staged `markdown` and `plaintext` files and fails the commit on any finding (override with `args: [--severity, error]` to only fail on errors).
+
+To also scan source-code comments, extend the hook:
+
+```yaml
+- id: llm-slop
+  args: [--scan-comments]
+  types_or: [markdown, plain-text, python, typescript, javascript, rust, go]
+```
 
 ### GitHub Actions
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "activationEvents": [
     "onLanguage:markdown",
-    "onLanguage:plaintext"
+    "onLanguage:plaintext",
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "bin": {
@@ -98,6 +99,33 @@
             "type": "string"
           },
           "description": "Override quick-fix replacements for specific characters. Key: the flagged character (e.g. \"—\" for em dash). Value: the replacement string. User overrides win over built-in and local-file rules."
+        },
+        "llmSlopDetector.scanCodeComments": {
+          "type": "boolean",
+          "default": false,
+          "description": "Scan comments and docstrings in source code files for LLM slop. Off by default; enable to widen scanning beyond markdown and plaintext."
+        },
+        "llmSlopDetector.codeCommentLanguages": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [
+            "typescript",
+            "javascript",
+            "typescriptreact",
+            "javascriptreact",
+            "python",
+            "rust",
+            "go",
+            "java",
+            "csharp",
+            "cpp",
+            "c",
+            "ruby",
+            "php",
+            "shellscript"
+          ],
+          "uniqueItems": true,
+          "description": "VS Code language IDs whose comments are scanned when scanCodeComments is true. Supported: typescript, javascript, typescriptreact, javascriptreact, python, rust, go, java, csharp, cpp, c, ruby, php, shellscript, swift, kotlin, scala, dart, perl, r, yaml. Unknown language IDs are ignored."
         }
       }
     },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ type CliOptions = {
   configPath?: string;
   severity: Severity;
   quiet: boolean;
+  scanComments: boolean;
 };
 
 type FileReport = {
@@ -23,7 +24,7 @@ type FileReport = {
   findings: Finding[];
 };
 
-const SCAN_EXTENSIONS = new Map<string, Language>([
+const PROSE_EXTENSIONS = new Map<string, Language>([
   ['.md', 'markdown'],
   ['.markdown', 'markdown'],
   ['.mdown', 'markdown'],
@@ -31,9 +32,34 @@ const SCAN_EXTENSIONS = new Map<string, Language>([
   ['.text', 'plaintext'],
 ]);
 
+const CODE_EXTENSIONS = new Map<string, Language>([
+  ['.ts', 'typescript'], ['.mts', 'typescript'], ['.cts', 'typescript'],
+  ['.tsx', 'typescriptreact'],
+  ['.js', 'javascript'], ['.mjs', 'javascript'], ['.cjs', 'javascript'],
+  ['.jsx', 'javascriptreact'],
+  ['.py', 'python'],
+  ['.rs', 'rust'],
+  ['.go', 'go'],
+  ['.java', 'java'],
+  ['.cs', 'csharp'],
+  ['.cpp', 'cpp'], ['.cxx', 'cpp'], ['.cc', 'cpp'], ['.hpp', 'cpp'], ['.hxx', 'cpp'],
+  ['.c', 'c'], ['.h', 'c'],
+  ['.rb', 'ruby'],
+  ['.php', 'php'],
+  ['.sh', 'shellscript'], ['.bash', 'shellscript'], ['.zsh', 'shellscript'],
+  ['.swift', 'swift'],
+  ['.kt', 'kotlin'], ['.kts', 'kotlin'],
+  ['.scala', 'scala'], ['.sc', 'scala'],
+  ['.dart', 'dart'],
+  ['.pl', 'perl'], ['.pm', 'perl'],
+  ['.r', 'r'],
+  ['.yaml', 'yaml'], ['.yml', 'yaml'],
+]);
+
 const HELP = `llm-slop-detector [options] <paths...>
 
 Scan markdown and plaintext files for LLM-style phrases and invisible Unicode.
+With --scan-comments, also scan comments and docstrings in source code.
 
 Options:
   -f, --format <pretty|json|sarif>  Output format (default: pretty)
@@ -44,6 +70,8 @@ Options:
                                     (default: nearest ancestor of cwd)
   -s, --severity <level>            Fail threshold: error | warning |
                                     information | hint (default: information)
+      --scan-comments               Scan comments/docstrings in source code
+                                    files (.ts, .py, .rs, .go, etc)
   -q, --quiet                       Suppress the summary line
   -h, --help                        Show this help
   -v, --version                     Print version
@@ -54,6 +82,7 @@ Examples:
   llm-slop-detector README.md
   llm-slop-detector --pack academic,cliches docs/
   llm-slop-detector --format=json . > slop.json
+  llm-slop-detector --scan-comments src/
 `;
 
 function parseCli(argv: string[]): CliOptions {
@@ -66,6 +95,7 @@ function parseCli(argv: string[]): CliOptions {
       'no-builtin': { type: 'boolean', default: false },
       config: { type: 'string' },
       severity: { type: 'string', short: 's', default: 'information' },
+      'scan-comments': { type: 'boolean', default: false },
       quiet: { type: 'boolean', short: 'q', default: false },
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'v', default: false },
@@ -112,6 +142,7 @@ function parseCli(argv: string[]): CliOptions {
     configPath: parsed.values.config as string | undefined,
     severity: severityRaw as Severity,
     quiet: parsed.values.quiet as boolean,
+    scanComments: parsed.values['scan-comments'] as boolean,
   };
 }
 
@@ -135,7 +166,7 @@ function extensionRoot(): string {
   return path.resolve(__dirname, '..');
 }
 
-function collectFiles(paths: string[]): string[] {
+function collectFiles(paths: string[], extensions: Map<string, Language>): string[] {
   const result: string[] = [];
   for (const p of paths) {
     const abs = path.resolve(p);
@@ -147,15 +178,20 @@ function collectFiles(paths: string[]): string[] {
       continue;
     }
     if (stat.isFile()) {
-      result.push(abs);
+      const ext = path.extname(abs).toLowerCase();
+      if (extensions.has(ext)) {
+        result.push(abs);
+      } else {
+        process.stderr.write(`llm-slop: skipping ${p} (unrecognized extension; add --scan-comments for source code)\n`);
+      }
     } else if (stat.isDirectory()) {
-      walkDir(abs, result);
+      walkDir(abs, extensions, result);
     }
   }
   return result;
 }
 
-function walkDir(dir: string, out: string[]): void {
+function walkDir(dir: string, extensions: Map<string, Language>, out: string[]): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -166,20 +202,20 @@ function walkDir(dir: string, out: string[]): void {
     if (e.name.startsWith('.') || e.name === 'node_modules' || e.name === 'out') continue;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
-      walkDir(full, out);
-    } else if (e.isFile() && SCAN_EXTENSIONS.has(path.extname(e.name).toLowerCase())) {
+      walkDir(full, extensions, out);
+    } else if (e.isFile() && extensions.has(path.extname(e.name).toLowerCase())) {
       out.push(full);
     }
   }
 }
 
-function languageFor(file: string): Language {
-  return SCAN_EXTENSIONS.get(path.extname(file).toLowerCase()) ?? 'plaintext';
+function languageFor(file: string, extensions: Map<string, Language>): Language {
+  return extensions.get(path.extname(file).toLowerCase()) ?? 'plaintext';
 }
 
-function scanFile(file: string, rules: RuleSet): Finding[] {
+function scanFile(file: string, rules: RuleSet, extensions: Map<string, Language>): Finding[] {
   const text = fs.readFileSync(file, 'utf8');
-  return scanText(text, rules, languageFor(file));
+  return scanText(text, rules, languageFor(file, extensions));
 }
 
 function shouldFail(reports: FileReport[], threshold: Severity): boolean {
@@ -323,8 +359,13 @@ function main(): void {
     charReplacements: {},
   });
 
-  const files = collectFiles(opts.paths);
-  const reports: FileReport[] = files.map(f => ({ path: f, findings: scanFile(f, rules) }));
+  const extensions = new Map<string, Language>(PROSE_EXTENSIONS);
+  if (opts.scanComments) {
+    for (const [k, v] of CODE_EXTENSIONS) extensions.set(k, v);
+  }
+
+  const files = collectFiles(opts.paths, extensions);
+  const reports: FileReport[] = files.map(f => ({ path: f, findings: scanFile(f, rules, extensions) }));
 
   let output: string;
   if (opts.format === 'json') output = formatJson(reports);

--- a/src/core/comments.ts
+++ b/src/core/comments.ts
@@ -1,0 +1,187 @@
+type Range = [number, number];
+
+export type CommentScanner = (text: string) => Range[];
+
+const C_STYLE_LANGS = new Set([
+  'typescript',
+  'javascript',
+  'typescriptreact',
+  'javascriptreact',
+  'rust',
+  'go',
+  'java',
+  'csharp',
+  'cpp',
+  'c',
+  'php',
+  'swift',
+  'kotlin',
+  'scala',
+  'dart',
+]);
+
+const PYTHON_LANGS = new Set(['python']);
+
+const HASH_LANGS = new Set(['ruby', 'shellscript', 'perl', 'r', 'yaml']);
+
+export const SUPPORTED_CODE_LANGUAGES: readonly string[] = [
+  ...C_STYLE_LANGS,
+  ...PYTHON_LANGS,
+  ...HASH_LANGS,
+].sort();
+
+export function getCommentScanner(language: string): CommentScanner | null {
+  if (C_STYLE_LANGS.has(language)) return scanCStyleComments;
+  if (PYTHON_LANGS.has(language)) return scanPythonComments;
+  if (HASH_LANGS.has(language)) return scanHashComments;
+  return null;
+}
+
+// Extract // line comments and /* */ block comments, skipping contents of
+// string literals (", ', `). Regex literals, division operators, and exotic
+// lexical edge cases are not disambiguated -- acceptable given findings are
+// Information severity and false positives are suppressible inline.
+function scanCStyleComments(text: string): Range[] {
+  const ranges: Range[] = [];
+  const n = text.length;
+  let i = 0;
+  let inString: '"' | "'" | '`' | null = null;
+
+  while (i < n) {
+    const c = text.charCodeAt(i);
+
+    if (inString !== null) {
+      if (c === 92 /* \ */ && i + 1 < n) { i += 2; continue; }
+      if (text[i] === inString) inString = null;
+      i++;
+      continue;
+    }
+
+    if (c === 47 /* / */ && i + 1 < n) {
+      const next = text.charCodeAt(i + 1);
+      if (next === 47 /* / */) {
+        const start = i;
+        const nl = text.indexOf('\n', i + 2);
+        const end = nl === -1 ? n : nl;
+        ranges.push([start, end]);
+        i = end;
+        continue;
+      }
+      if (next === 42 /* * */) {
+        const start = i;
+        const close = text.indexOf('*/', i + 2);
+        const end = close === -1 ? n : close + 2;
+        ranges.push([start, end]);
+        i = end;
+        continue;
+      }
+    }
+
+    if (c === 34 /* " */ || c === 39 /* ' */ || c === 96 /* ` */) {
+      inString = text[i] as '"' | "'" | '`';
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return ranges;
+}
+
+// Extract # line comments and triple-quoted strings. Triple-quoted strings
+// are scanned whether they're docstrings or raw data -- Option A can't
+// distinguish without a parser, and the issue accepts this tradeoff.
+function scanPythonComments(text: string): Range[] {
+  const ranges: Range[] = [];
+  const n = text.length;
+  let i = 0;
+  let inString: { quote: string; triple: boolean } | null = null;
+
+  while (i < n) {
+    if (inString !== null) {
+      if (inString.triple) {
+        if (text.startsWith(inString.quote.repeat(3), i)) {
+          i += 3;
+          inString = null;
+          continue;
+        }
+      } else {
+        if (text[i] === '\\' && i + 1 < n) { i += 2; continue; }
+        if (text[i] === inString.quote || text[i] === '\n') {
+          inString = null;
+        }
+      }
+      i++;
+      continue;
+    }
+
+    if (text.startsWith('"""', i) || text.startsWith("'''", i)) {
+      const quote = text[i];
+      const start = i;
+      i += 3;
+      const closerIdx = text.indexOf(quote.repeat(3), i);
+      const end = closerIdx === -1 ? n : closerIdx + 3;
+      ranges.push([start, end]);
+      i = end;
+      continue;
+    }
+
+    if (text[i] === '#') {
+      const start = i;
+      const nl = text.indexOf('\n', i + 1);
+      const end = nl === -1 ? n : nl;
+      ranges.push([start, end]);
+      i = end;
+      continue;
+    }
+
+    if (text[i] === '"' || text[i] === "'") {
+      inString = { quote: text[i], triple: false };
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return ranges;
+}
+
+// Extract # line comments, skipping contents of string literals.
+// Works for Ruby, shell, Perl, R, YAML, etc. Heredocs and `$# ` parameter
+// expansion are not specially handled.
+function scanHashComments(text: string): Range[] {
+  const ranges: Range[] = [];
+  const n = text.length;
+  let i = 0;
+  let inString: '"' | "'" | null = null;
+
+  while (i < n) {
+    if (inString !== null) {
+      if (text[i] === '\\' && i + 1 < n) { i += 2; continue; }
+      if (text[i] === inString || text[i] === '\n') inString = null;
+      i++;
+      continue;
+    }
+
+    if (text[i] === '#') {
+      const start = i;
+      const nl = text.indexOf('\n', i + 1);
+      const end = nl === -1 ? n : nl;
+      ranges.push([start, end]);
+      i = end;
+      continue;
+    }
+
+    if (text[i] === '"' || text[i] === "'") {
+      inString = text[i] as '"' | "'";
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return ranges;
+}

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -1,6 +1,7 @@
 import { CharRule, Finding, RuleSet } from './types';
+import { getCommentScanner } from './comments';
 
-export type Language = 'markdown' | 'plaintext';
+export type Language = string;
 
 type Range = [number, number];
 
@@ -27,7 +28,8 @@ export function charDiagnosticMessage(def: CharRule): string {
 
 export function scanText(text: string, rules: RuleSet, language: Language): Finding[] {
   const findings: Finding[] = [];
-  const excluded = language === 'markdown' ? computeMarkdownExclusions(text) : [];
+  const excluded = computeExcludedRanges(text, language);
+  if (excluded === null) return findings;
   const suppressions = computeSuppressions(text, excluded);
 
   rules.charRegex.lastIndex = 0;
@@ -72,8 +74,32 @@ export function scanText(text: string, rules: RuleSet, language: Language): Find
 }
 
 // ---------------------------------------------------------------------------
-// Scope: markdown exclusions + inline ignore directives
+// Scope: markdown exclusions, code-comment inclusion, inline ignore directives
 // ---------------------------------------------------------------------------
+
+// Returns the ranges that should be SKIPPED during scanning. null means the
+// language isn't supported and the file should not be scanned at all.
+function computeExcludedRanges(text: string, language: Language): Range[] | null {
+  if (language === 'markdown') return computeMarkdownExclusions(text);
+  if (language === 'plaintext') return [];
+
+  const commentScanner = getCommentScanner(language);
+  if (commentScanner === null) return null;
+
+  const comments = mergeRanges(commentScanner(text));
+  return invertRanges(comments, text.length);
+}
+
+function invertRanges(ranges: Range[], textLen: number): Range[] {
+  const inverted: Range[] = [];
+  let cursor = 0;
+  for (const [s, e] of ranges) {
+    if (s > cursor) inverted.push([cursor, s]);
+    cursor = Math.max(cursor, e);
+  }
+  if (cursor < textLen) inverted.push([cursor, textLen]);
+  return inverted;
+}
 
 function mergeRanges(ranges: Range[]): Range[] {
   if (ranges.length === 0) return ranges;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,23 @@
 import * as vscode from 'vscode';
 import { LOCAL_RULES_FILENAME, RuleSet, loadRules, severityToVscode } from './rules';
 import { Language, scanText } from './core/scan';
+import { SUPPORTED_CODE_LANGUAGES } from './core/comments';
 
 const SOURCE = 'LLM Slop';
-const SUPPORTED_LANGS = new Set<Language>(['markdown', 'plaintext']);
-const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [
-  { language: 'markdown' },
-  { language: 'plaintext' },
-];
+const BASE_LANGS: Language[] = ['markdown', 'plaintext'];
+let SUPPORTED_LANGS = new Set<Language>(BASE_LANGS);
+const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [{ scheme: 'file' }, { scheme: 'untitled' }];
+
+function rebuildSupportedLangs() {
+  const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
+  const scanComments = cfg.get<boolean>('scanCodeComments', false);
+  const codeLangs = cfg.get<string[]>('codeCommentLanguages', []);
+  const allowed = new Set(SUPPORTED_CODE_LANGUAGES);
+  SUPPORTED_LANGS = new Set<Language>([
+    ...BASE_LANGS,
+    ...(scanComments ? codeLangs.filter(l => allowed.has(l)) : []),
+  ]);
+}
 
 // Module-level mutable rule state. Rebuilt on config change / rule-file change
 // and scans read through it.
@@ -148,6 +158,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const reloadRules = () => {
     RULES = loadRules(context.extensionUri);
+    rebuildSupportedLangs();
     vscode.workspace.textDocuments.forEach(refresh);
     updateStatus();
   };


### PR DESCRIPTION
Closes #25. Completes the top-three checklist from #22.

## Summary

- **` src/core/comments.ts ` (new)**: lexical extractors for three comment families:
  - C-style (` // `, ` /* */ `) for TypeScript, JavaScript, React flavours, Rust, Go, Java, C#, C/C++, PHP, Swift, Kotlin, Scala, Dart
  - Python (` # `, ` \"\"\"...\"\"\" `, ` '''...''' `)
  - Hash-only (` # `) for Ruby, shell, Perl, R, YAML
  - Scanners track string-literal state so ` const msg = \"delve\"; ` doesn't flag as a comment
- **` src/core/scan.ts `**: widens ` Language ` to ` string `; when the language isn't ` markdown ` or ` plaintext `, looks up a comment scanner and inverts comment ranges into the existing excluded-range filter. Unknown languages produce zero findings.
- **Extension settings**:
  - ` llmSlopDetector.scanCodeComments ` (default ` false ` -- existing users see no change)
  - ` llmSlopDetector.codeCommentLanguages ` (default: 14 common language IDs)
  - Activation widens to ` onStartupFinished ` so code files get picked up without opening a markdown file first
  - Code-action selector widens to ` { scheme: 'file' } ` so fixes work inside JSDoc / docstrings
- **CLI**:
  - ` --scan-comments ` flag
  - Extension-to-language map covers 24+ file extensions
  - Explicit files with unknown extensions are now skipped with a stderr warning rather than silently scanned as plaintext
- **README / CLAUDE.md**: new \"Source code comments (opt-in)\" section, pre-commit recipe for code comments, CLI flag documented

## Acceptance from #25

- [x] ` scanCodeComments: true `, JSDoc containing ` delve ` -> diagnostic on the comment range (verified via CLI ` --scan-comments /tmp/sloppy.ts `, 12 findings all inside comments)
- [x] Code outside comments produces no diagnostics (verified: ` const delveString = \"delve\" ` in the fixture didn't flag)
- [x] Python triple-quoted docstrings scanned (verified: ` \"\"\"Delve into...\"\"\" ` flags)
- [x] Turning setting off stops all code-file diagnostics (` reloadRules() ` recomputes ` SUPPORTED_LANGS ` on config change and clears diagnostics for docs no longer covered)
- [x] Extension and CLI produce identical findings (share ` core/scan.ts ` by construction)
- [ ] Performance on a 5k-line TS file stays under ~50ms per scan -- not benchmarked; scanners are single-pass O(n) so should be well within budget, but worth measuring if a heavy user reports slowness

## Known simplifications (documented in README)

- Python triple-quoted strings used as data are scanned too (parser-free lexing can't distinguish from docstrings).
- JS regex literals aren't specially recognised; exotic edge cases may misparse.
- Nested block comments: the first ` */ ` closes the outer block (rare in practice).

## Test plan

- [ ] F5 in VS Code with ` scanCodeComments: true `: open a ` .ts ` file with slop in JSDoc -- diagnostic squiggles appear on the comment only, not on string contents.
- [ ] Toggle ` scanCodeComments ` off and back on: diagnostics clear, then reappear on the next scan.
- [ ] Explicit ` llm-slop foo.ts ` without ` --scan-comments `: prints skip warning, exit 0.
- [ ] Explicit ` llm-slop --scan-comments foo.ts `: scans comment ranges only.
- [ ] Directory walk with ` --scan-comments ` picks up ` .py ` and ` .rs ` files.
- [ ] CLI JSON output is unchanged in shape (same keys, new values when scanning comments).
- [ ] Existing markdown / plaintext behaviour unchanged (` ./out/cli.js README.md ` still reports the same findings as before this PR).