### PR TITLE
feat: add "Scan selection" command for one-off checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Settings (Cmd/Ctrl+, then search "LLM Slop"):
 - **LLM Slop Detector: Open settings**: jump to this extension's settings filtered by `@ext:` query
 - **LLM Slop Detector: Show loaded rule sources**: quick pick listing every active source with name, version, and rule counts
 - **LLM Slop Detector: Show onboarding**: re-show the onboarding prompt (useful if you dismissed it too early)
+- **LLM Slop Detector: Scan selection**: list slop findings in the current selection (or the current line if nothing is selected) in a quick pick -- clicking a finding jumps to it. Useful for checking a pasted paragraph without scrolling through every diagnostic in the file.
 
 ## Rule sources
 

--- a/package.json
+++ b/package.json
@@ -145,6 +145,10 @@
       {
         "command": "llmSlopDetector.showOnboarding",
         "title": "LLM Slop Detector: Show onboarding"
+      },
+      {
+        "command": "llmSlopDetector.scanSelection",
+        "title": "LLM Slop Detector: Scan selection"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,6 +204,7 @@ export function activate(context: vscode.ExtensionContext) {
       );
     }),
     vscode.commands.registerCommand('llmSlopDetector.showOnboarding', () => showOnboarding(context)),
+    vscode.commands.registerCommand('llmSlopDetector.scanSelection', () => scanSelection()),
     vscode.commands.registerCommand('llmSlopDetector.showRuleSources', async () => {
       if (RULES.sources.length === 0) {
         vscode.window.showInformationMessage('LLM Slop Detector: no rule sources loaded.');
@@ -219,6 +220,69 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   void maybeShowOnboarding(context);
+}
+
+// ---------------------------------------------------------------------------
+// Scan selection
+// ---------------------------------------------------------------------------
+
+function severityCodicon(s: vscode.DiagnosticSeverity): string {
+  switch (s) {
+    case vscode.DiagnosticSeverity.Error: return 'error';
+    case vscode.DiagnosticSeverity.Warning: return 'warning';
+    case vscode.DiagnosticSeverity.Information: return 'info';
+    case vscode.DiagnosticSeverity.Hint: return 'lightbulb';
+  }
+}
+
+async function scanSelection(): Promise<void> {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor) {
+    vscode.window.showInformationMessage('LLM Slop Detector: no active editor.');
+    return;
+  }
+  const doc = editor.document;
+  if (!SUPPORTED_LANGS.has(doc.languageId as Language)) {
+    vscode.window.showInformationMessage(
+      `LLM Slop Detector: ${doc.languageId} is not a scanned language.`
+    );
+    return;
+  }
+
+  const sel = editor.selection;
+  const scope = sel.isEmpty ? doc.lineAt(sel.start).range : new vscode.Range(sel.start, sel.end);
+
+  const diags = vscode.languages.getDiagnostics(doc.uri)
+    .filter(d => d.source === SOURCE && scope.intersection(d.range))
+    .sort((a, b) => a.range.start.compareTo(b.range.start));
+
+  if (diags.length === 0) {
+    vscode.window.showInformationMessage(
+      sel.isEmpty
+        ? 'LLM Slop Detector: no findings on this line.'
+        : 'LLM Slop Detector: no findings in selection.'
+    );
+    return;
+  }
+
+  type Item = vscode.QuickPickItem & { diagnostic: vscode.Diagnostic };
+  const items: Item[] = diags.map(d => ({
+    label: `$(${severityCodicon(d.severity)}) ${doc.getText(d.range).trim() || String(d.code)}`,
+    description: `Line ${d.range.start.line + 1}, col ${d.range.start.character + 1}`,
+    detail: d.message,
+    diagnostic: d,
+  }));
+
+  const pick = await vscode.window.showQuickPick(items, {
+    title: `LLM Slop in ${sel.isEmpty ? 'line' : 'selection'} (${diags.length} finding${diags.length === 1 ? '' : 's'})`,
+    matchOnDescription: true,
+    matchOnDetail: true,
+  });
+
+  if (pick) {
+    editor.revealRange(pick.diagnostic.range, vscode.TextEditorRevealType.InCenter);
+    editor.selection = new vscode.Selection(pick.diagnostic.range.start, pick.diagnostic.range.end);
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Addresses a minor gap from #22: no way to quickly check a pasted paragraph without scanning past every other finding in the file.

Adds command ` LLM Slop Detector: Scan selection `:
- Picks up the active editor's selection, or the current line if the selection is empty.
- Lists LLM Slop findings in the scope via a quick pick, with severity icon, ` line:col `, and the full diagnostic message in detail.
- Clicking a finding reveals and selects its range.
- Shows a friendly info message on \"no findings\" or when the language isn't scanned.

Reuses the existing diagnostic collection -- no re-scan, no duplicate work. Findings outside the selection are filtered out via ` range.intersection `.

## Test plan

- [ ] F5: open a Markdown file with multiple slop findings. With cursor on a clean line, run the command -> \"no findings on this line\".
- [ ] Select a paragraph containing 3 findings, run the command -> quick pick shows 3 items with correct line/col and severity icons.
- [ ] Pick one -> editor reveals and selects that range.
- [ ] Run on an unscanned language (e.g. ` json `) -> \"not a scanned language\" message.
- [ ] Run with ` --scan-comments ` enabled on a ` .ts ` file -> comment-range findings are included.