### PR TITLE
feat: show rule selector and ignore snippet on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A VS Code extension and CLI that flag invisible Unicode, AI-style punctuation, a
 - Configurable phrase rules: ~40 built-in core rules plus six opt-in packs (`academic`, `cliches`, `fiction`, `claudeisms`, `structural`, `security`) totalling 285+ curated regex patterns
 - Markdown-aware: skips fenced and inline code, link URLs, and YAML frontmatter so technical prose doesn't drown in false positives
 - Inline-ignore comments (`<!-- slop-disable -->`, `<!-- slop-disable-next-line -->`, `<!-- slop-disable-line -->`) for one-off exceptions
+- Hover over any flagged range for the rule selector plus a ready-to-copy `slop-disable-next-line` snippet
 - Per-workspace overrides via `.llmsloprc.json` and per-user overrides via settings
 - One-click quick fixes for deterministic character replacements, plus a "fix all" action
 - Status-bar slop counter for the active file, click to toggle

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { LOCAL_RULES_FILENAME, RuleSet, loadRules, severityToVscode } from './rules';
 import { Language, scanText } from './core/scan';
 import { SUPPORTED_CODE_LANGUAGES } from './core/comments';
+import { Finding } from './core/types';
 
 const SOURCE = 'LLM Slop';
 const BASE_LANGS: Language[] = ['markdown', 'plaintext'];
@@ -23,14 +24,22 @@ function rebuildSupportedLangs() {
 // and scans read through it.
 let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(?!)/g };
 
+// Findings keyed by document URI, stashed during scan so the hover provider
+// can recover rule metadata (pattern, matched char) without rescanning.
+const FINDINGS_BY_URI = new Map<string, Finding[]>();
+
 function getReplacement(char: string): string | undefined {
   return RULES.chars.get(char)?.replacement;
 }
 
 function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
   const lang = doc.languageId as Language;
-  if (!SUPPORTED_LANGS.has(lang)) return [];
+  if (!SUPPORTED_LANGS.has(lang)) {
+    FINDINGS_BY_URI.delete(doc.uri.toString());
+    return [];
+  }
   const findings = scanText(doc.getText(), RULES, lang);
+  FINDINGS_BY_URI.set(doc.uri.toString(), findings);
   return findings.map(f => {
     const start = doc.positionAt(f.offset);
     const end = doc.positionAt(f.offset + f.length);
@@ -99,6 +108,52 @@ class SlopCodeActionProvider implements vscode.CodeActionProvider {
     }
 
     return actions;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hover provider: show rule metadata + ready-to-copy ignore snippet
+// ---------------------------------------------------------------------------
+
+function charCodepointSpec(char: string): string {
+  return 'U+' + char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0');
+}
+
+function ignoreSpecFor(f: Finding): string {
+  return f.code === 'phrase' && f.rulePattern !== undefined
+    ? `phrase:${f.rulePattern}`
+    : `char:${charCodepointSpec(f.matchText)}`;
+}
+
+class SlopHoverProvider implements vscode.HoverProvider {
+  provideHover(document: vscode.TextDocument, position: vscode.Position): vscode.Hover | undefined {
+    const findings = FINDINGS_BY_URI.get(document.uri.toString());
+    if (!findings || findings.length === 0) return;
+
+    const offset = document.offsetAt(position);
+    const matched = findings.filter(f => offset >= f.offset && offset < f.offset + f.length);
+    if (matched.length === 0) return;
+
+    const blocks = matched.map(f => {
+      const spec = ignoreSpecFor(f);
+      const heading = f.code === 'phrase' ? 'LLM-style phrase' : 'Flagged character';
+      const lines = [
+        `**${heading}** -- \`${f.source}\``,
+        '',
+        `Rule selector: \`${spec}\``,
+        '',
+        'Suppress the next line:',
+        '```markdown',
+        `<!-- slop-disable-next-line ${spec} -->`,
+        '```',
+      ];
+      return lines.join('\n');
+    });
+
+    const md = new vscode.MarkdownString(blocks.join('\n\n---\n\n'));
+    md.isTrusted = false;
+    md.supportHtml = false;
+    return new vscode.Hover(md);
   }
 }
 
@@ -179,7 +234,11 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument(doc => { refresh(doc); updateStatus(); }),
     vscode.workspace.onDidChangeTextDocument(e => { refresh(e.document); updateStatus(); }),
-    vscode.workspace.onDidCloseTextDocument(doc => { collection.delete(doc.uri); updateStatus(); }),
+    vscode.workspace.onDidCloseTextDocument(doc => {
+      collection.delete(doc.uri);
+      FINDINGS_BY_URI.delete(doc.uri.toString());
+      updateStatus();
+    }),
     vscode.workspace.onDidChangeWorkspaceFolders(reloadRules),
     vscode.window.onDidChangeActiveTextEditor(() => updateStatus()),
     vscode.languages.onDidChangeDiagnostics(() => updateStatus()),
@@ -191,6 +250,7 @@ export function activate(context: vscode.ExtensionContext) {
       new SlopCodeActionProvider(),
       { providedCodeActionKinds: SlopCodeActionProvider.providedCodeActionKinds }
     ),
+    vscode.languages.registerHoverProvider(CODE_ACTION_SELECTORS, new SlopHoverProvider()),
     vscode.commands.registerCommand('llmSlopDetector.toggle', async () => {
       const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
       const current = cfg.get<boolean>('enabled', true);


### PR DESCRIPTION
Addresses a minor gap from #22: the diagnostic message says *what* was flagged but not *how to suppress it*. Users have to reverse-engineer the rule pattern from ` .llmsloprc.json ` to write a scoped ignore directive.

New hover provider returns, for any LLM Slop diagnostic under the cursor:

- Rule source (built-in, pack name, or local rule file)
- Suppression selector: ` phrase:<regex> ` or ` char:U+XXXX `
- Ready-to-copy ` <!-- slop-disable-next-line <selector> --> ` snippet

Implementation:

- Extension caches ` Finding[] ` per ` document.uri ` during scan so the hover can look up ` rulePattern ` and ` matchText ` without rescanning.
- Registered on the same selector as the code action provider (` { scheme: 'file' } ` + ` untitled `). Provider is a no-op when no findings exist at the hover position, so it's cheap.
- Cache entry is cleared on ` onDidCloseTextDocument ` to avoid leaks.

The default diagnostic hover (from VS Code) still shows as before; this provider adds a complementary block below it.

## Test plan

- [ ] F5: hover on an ` em dash ` diagnostic -> shows ` char:U+2014 ` and a snippet.
- [ ] Hover on a ` delve ` phrase diagnostic -> shows ` phrase:\bdelve(s|d|ing)?\b ` and a snippet.
- [ ] Copy the snippet into the file above the line -> diagnostic disappears after the next scan.
- [ ] Hover on non-slop content -> no hover block from this provider.
- [ ] Close and reopen the file -> cache rebuilds, hover still works.
- [ ] Diagnostics stacked at the same position (rare but possible) -> all entries render in one hover, separated by ` --- `.