### PR TITLE
feat: link diagnostics to rule documentation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,12 @@ function getReplacement(char: string): string | undefined {
   return RULES.chars.get(char)?.replacement;
 }
 
+function diagnosticCode(d: vscode.Diagnostic): string | number | undefined {
+  const c = d.code;
+  if (typeof c === 'object' && c !== null) return c.value;
+  return c;
+}
+
 function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
   const lang = doc.languageId as Language;
   if (!SUPPORTED_LANGS.has(lang)) return [];
@@ -37,8 +43,7 @@ function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
     const end = doc.positionAt(f.offset + f.length);
     const d = new vscode.Diagnostic(new vscode.Range(start, end), f.message, severityToVscode(f.severity));
     d.source = SOURCE;
-    d.code = f.code;
-    d.codeDescription = { href: DOCS_URI };
+    d.code = { value: f.code, target: DOCS_URI };
     return d;
   });
 }
@@ -58,7 +63,7 @@ class SlopCodeActionProvider implements vscode.CodeActionProvider {
     const actions: vscode.CodeAction[] = [];
 
     for (const diag of context.diagnostics) {
-      if (diag.source !== SOURCE || diag.code !== 'char') continue;
+      if (diag.source !== SOURCE || diagnosticCode(diag) !== 'char') continue;
       const char = document.getText(diag.range);
       const replacement = getReplacement(char);
       if (replacement === undefined) continue;
@@ -79,11 +84,11 @@ class SlopCodeActionProvider implements vscode.CodeActionProvider {
     }
 
     const contextHasFixableChar = context.diagnostics.some(d =>
-      d.source === SOURCE && d.code === 'char' &&
+      d.source === SOURCE && diagnosticCode(d) === 'char' &&
       getReplacement(document.getText(d.range)) !== undefined
     );
     const fixable = vscode.languages.getDiagnostics(document.uri)
-      .filter(d => d.source === SOURCE && d.code === 'char')
+      .filter(d => d.source === SOURCE && diagnosticCode(d) === 'char')
       .filter(d => getReplacement(document.getText(d.range)) !== undefined);
     if (contextHasFixableChar && fixable.length > 0) {
       const fixAll = new vscode.CodeAction(
@@ -141,8 +146,8 @@ export function activate(context: vscode.ExtensionContext) {
     }
     const diags = vscode.languages.getDiagnostics(editor.document.uri)
       .filter(d => d.source === SOURCE);
-    const chars = diags.filter(d => d.code === 'char').length;
-    const phrases = diags.filter(d => d.code === 'phrase').length;
+    const chars = diags.filter(d => diagnosticCode(d) === 'char').length;
+    const phrases = diags.filter(d => diagnosticCode(d) === 'phrase').length;
     const total = chars + phrases;
     if (total === 0) {
       status.text = '$(check) No slop';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { Language, scanText } from './core/scan';
 import { SUPPORTED_CODE_LANGUAGES } from './core/comments';
 
 const SOURCE = 'LLM Slop';
+const DOCS_URI = vscode.Uri.parse('https://github.com/mandakan/llm-slop-detector#what-it-flags');
 const BASE_LANGS: Language[] = ['markdown', 'plaintext'];
 let SUPPORTED_LANGS = new Set<Language>(BASE_LANGS);
 const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [{ scheme: 'file' }, { scheme: 'untitled' }];
@@ -37,6 +38,7 @@ function scanDocument(doc: vscode.TextDocument): vscode.Diagnostic[] {
     const d = new vscode.Diagnostic(new vscode.Range(start, end), f.message, severityToVscode(f.severity));
     d.source = SOURCE;
     d.code = f.code;
+    d.codeDescription = { href: DOCS_URI };
     return d;
   });
 }


### PR DESCRIPTION
Addresses a minor gap from #22: the ` code ` column in the Problems panel (` char ` / ` phrase `) is inert. Setting ` Diagnostic.code ` to the composite ` { value, target } ` shape makes it render as a clickable link to the README's \"What it flags\" section -- one-line diff plus a helper for the call sites that compared ` code ` as a string.

## Notes

- Initial attempt used ` d.codeDescription = {...} ` (not on the ` Diagnostic ` surface); corrected to ` d.code = { value, target } ` in the follow-up commit on this branch. A squash merge rolls both into a single clean commit on main.
- ` diagnosticCode() ` helper normalises the two shapes so the code-action provider and status-bar counts keep working.
- URL is a constant for now; per-rule anchors are tracked as a follow-up if needed.

## Test plan

- [ ] F5: open a markdown file with slop; confirm the Problems-panel ` char ` / ` phrase ` cell is now underlined and opens the README section in a browser.
- [ ] Quick fixes still appear on char diagnostics (uses ` diagnosticCode(d) === 'char' `).
- [ ] Status bar still counts chars and phrases separately (same helper).