### PR TITLE
fix: skip local rule files on untrusted workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,17 @@ Rules merge from these layers (later overrides earlier on the same char or patte
 
 1. Built-in core list shipped with the extension
 2. Optional built-in packs listed in `llmSlopDetector.enabledPacks`
-3. Local `.llmsloprc.json` in a workspace folder's root (auto-loaded, live-reloaded)
+3. Local `.llmsloprc.json` in a workspace folder's root (auto-loaded, live-reloaded). Skipped in untrusted workspaces -- see [Workspace trust](#workspace-trust).
 4. User settings
+
+### Workspace trust
+
+Local `.llmsloprc.json` files contain arbitrary regex patterns compiled and executed by the extension. A catastrophic-backtracking pattern in a repo you opened for the first time could hang the extension host. So:
+
+- In a **trusted** workspace, all four rule layers load as usual.
+- In an **untrusted** workspace (VS Code's Restricted Mode), local rule files are skipped. Built-in rules, packs, and user-level settings still apply, so the extension remains useful out of the box.
+
+Trust is granted per-workspace via VS Code's "Manage Workspace Trust" command. The extension listens for trust grants and re-scans open documents when you flip a workspace to trusted.
 
 ### `.llmsloprc.json` format
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,12 @@
   "bin": {
     "llm-slop": "./out/cli.js"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "In an untrusted workspace, local .llmsloprc.json files are skipped to avoid running arbitrary regex patterns from an unknown source. Built-in rules, packs, and user-level settings still apply."
+    }
+  },
   "contributes": {
     "configuration": {
       "title": "LLM Slop Detector",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -181,6 +181,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeTextDocument(e => { refresh(e.document); updateStatus(); }),
     vscode.workspace.onDidCloseTextDocument(doc => { collection.delete(doc.uri); updateStatus(); }),
     vscode.workspace.onDidChangeWorkspaceFolders(reloadRules),
+    vscode.workspace.onDidGrantWorkspaceTrust(reloadRules),
     vscode.window.onDidChangeActiveTextEditor(() => updateStatus()),
     vscode.languages.onDidChangeDiagnostics(() => updateStatus()),
     vscode.workspace.onDidChangeConfiguration(e => {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -17,6 +17,10 @@ export function severityToVscode(s: Severity): vscode.DiagnosticSeverity {
 }
 
 function getLocalRulePaths(): string[] {
+  // Workspace rule files ship arbitrary regex. In an untrusted workspace we
+  // fall back to built-in rules only; a catastrophic-backtracking pattern in
+  // a random repo shouldn't be able to wedge the extension host.
+  if (!vscode.workspace.isTrusted) return [];
   const paths: string[] = [];
   for (const folder of vscode.workspace.workspaceFolders ?? []) {
     const p = path.join(folder.uri.fsPath, LOCAL_RULES_FILENAME);


### PR DESCRIPTION
Addresses the last minor gap from #22 we're tackling in this batch.

Local ` .llmsloprc.json ` files contain arbitrary regex patterns that the extension compiles and executes. A catastrophic-backtracking pattern (e.g. ` (a+)+$ ` on a pathological input) in a repo you opened for the first time could wedge the extension host.

Fix:

- ` capabilities.untrustedWorkspaces: { supported: 'limited', description: ... } ` in ` package.json ` so VS Code shows the standard Restricted Mode banner.
- ` getLocalRulePaths() ` in ` src/rules.ts ` returns ` [] ` when ` vscode.workspace.isTrusted ` is false. Built-in rules, packs, and user-level settings still apply, so the extension remains useful with zero configuration.
- ` onDidGrantWorkspaceTrust ` triggers ` reloadRules ` so local rules kick in the moment the user grants trust, without a restart.
- README gains a \"Workspace trust\" subsection under Rule sources.

## Test plan

- [ ] Open a repo in Restricted Mode (e.g. right-click a folder, \"Open in Restricted Mode\"): extension loads built-in rules only; a local ` .llmsloprc.json ` in the repo is ignored.
- [ ] Run \"Manage Workspace Trust\" -> Trust. Diagnostics refresh and the local rules now apply.
- [ ] ` Show loaded rule sources ` confirms the expected layers in each mode.