### PR TITLE
perf: debounce document scanning on keystrokes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "llm-slop-detector",
       "version": "0.5.0",
       "license": "MIT",
+      "bin": {
+        "llm-slop": "out/cli.js"
+      },
       "devDependencies": {
         "@types/node": "^25.6.0",
         "@types/vscode": "^1.95.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,13 @@
           },
           "description": "Override quick-fix replacements for specific characters. Key: the flagged character (e.g. \"—\" for em dash). Value: the replacement string. User overrides win over built-in and local-file rules."
         },
+        "llmSlopDetector.debounceMs": {
+          "type": "number",
+          "default": 150,
+          "minimum": 0,
+          "maximum": 2000,
+          "description": "Milliseconds to wait after the last edit before rescanning the document. Collapses rapid keystrokes into a single scan. Set to 0 for instant feedback on small files."
+        },
         "llmSlopDetector.scanCodeComments": {
           "type": "boolean",
           "default": false,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,21 @@ let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(
 // can recover rule metadata (pattern, matched char) without rescanning.
 const FINDINGS_BY_URI = new Map<string, Finding[]>();
 
+// Pending debounced refreshes keyed by document URI. Leading-edge scan fires
+// immediately on the first change after idle; `trailing` flips to true when
+// further changes arrive during the debounce window, triggering one more scan
+// when the timer expires.
+type PendingRefresh = { timer: NodeJS.Timeout; trailing: boolean };
+const PENDING_REFRESH = new Map<string, PendingRefresh>();
+
+function cancelPendingRefresh(uriKey: string): void {
+  const p = PENDING_REFRESH.get(uriKey);
+  if (p !== undefined) {
+    clearTimeout(p.timer);
+    PENDING_REFRESH.delete(uriKey);
+  }
+}
+
 function getReplacement(char: string): string | undefined {
   return RULES.chars.get(char)?.replacement;
 }
@@ -181,6 +196,36 @@ export function activate(context: vscode.ExtensionContext) {
     collection.set(doc.uri, scanDocument(doc));
   };
 
+  // Leading+trailing debounce: first change after idle triggers an immediate
+  // scan so feedback stays snappy; subsequent changes within the window
+  // collapse into one trailing scan when the timer fires.
+  const scheduleRefresh = (doc: vscode.TextDocument) => {
+    const key = doc.uri.toString();
+    const raw = vscode.workspace.getConfiguration('llmSlopDetector').get<number>('debounceMs', 150);
+    const ms = Number.isFinite(raw) ? Math.max(0, Math.min(2000, raw)) : 150;
+
+    if (ms === 0) {
+      cancelPendingRefresh(key);
+      refresh(doc);
+      return;
+    }
+
+    const existing = PENDING_REFRESH.get(key);
+    if (existing !== undefined) {
+      existing.trailing = true;
+      return;
+    }
+
+    refresh(doc);
+    const entry: PendingRefresh = { timer: undefined as unknown as NodeJS.Timeout, trailing: false };
+    entry.timer = setTimeout(() => {
+      const current = PENDING_REFRESH.get(key);
+      PENDING_REFRESH.delete(key);
+      if (current?.trailing) refresh(doc);
+    }, ms);
+    PENDING_REFRESH.set(key, entry);
+  };
+
   const status = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);
   status.command = 'llmSlopDetector.toggle';
   context.subscriptions.push(status);
@@ -240,10 +285,12 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument(doc => { refresh(doc); updateStatus(); }),
-    vscode.workspace.onDidChangeTextDocument(e => { refresh(e.document); updateStatus(); }),
+    vscode.workspace.onDidChangeTextDocument(e => { scheduleRefresh(e.document); }),
     vscode.workspace.onDidCloseTextDocument(doc => {
+      const key = doc.uri.toString();
+      cancelPendingRefresh(key);
       collection.delete(doc.uri);
-      FINDINGS_BY_URI.delete(doc.uri.toString());
+      FINDINGS_BY_URI.delete(key);
       updateStatus();
     }),
     vscode.workspace.onDidChangeWorkspaceFolders(reloadRules),
@@ -393,4 +440,7 @@ async function showOnboarding(context: vscode.ExtensionContext) {
   }
 }
 
-export function deactivate() { /* diagnostics are disposed via subscriptions */ }
+export function deactivate() {
+  for (const { timer } of PENDING_REFRESH.values()) clearTimeout(timer);
+  PENDING_REFRESH.clear();
+}


### PR DESCRIPTION
Collapse rapid onDidChangeTextDocument events into a single rescan per
document via a per-URI leading+trailing debounce. First change after
idle fires immediately; further changes within the window trigger one
trailing scan when the timer expires. Configurable via the new
llmSlopDetector.debounceMs setting (default 150 ms, min 0, max 2000).

Closes #41