### PR TITLE
feat: scan git commit messages and SCM input box

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,10 @@
   entry: llm-slop
   language: node
   types_or: [markdown, plain-text]
+- id: llm-slop-commit-msg
+  name: LLM Slop Detector (commit message)
+  description: Flag LLM slop in commit messages before they land.
+  entry: llm-slop
+  language: node
+  stages: [commit-msg]
+  types: [text]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Settings (Cmd/Ctrl+, then search "LLM Slop"):
 - `llmSlopDetector.enabledPacks`: opt-in extra rule packs (see [Rule packs](#rule-packs)). Default: `[]`.
 - `llmSlopDetector.phrases`: additional regex patterns, appended to the built-in list.
 - `llmSlopDetector.charReplacements`: override quick-fix replacements per character.
+- `llmSlopDetector.scanCommitMessages`: scan Git commit editor buffers (`git-commit`) and the VS Code Source Control input box (`scminput`). Default `true`.
 
 ## Commands
 
@@ -286,6 +287,19 @@ repos:
 ```
 
 Pin to a released tag. The hook runs on staged `markdown` and `plaintext` files and fails the commit on any finding (override with `args: [--severity, error]` to only fail on errors).
+
+There's also a `commit-msg` stage hook that scans the commit message itself before it lands:
+
+```yaml
+repos:
+  - repo: https://github.com/mandakan/llm-slop-detector
+    rev: v0.5.0
+    hooks:
+      - id: llm-slop-commit-msg
+        stages: [commit-msg]
+```
+
+The CLI recognises `COMMIT_EDITMSG`, `MERGE_MSG`, `TAG_EDITMSG`, and `EDIT_DESCRIPTION` by basename and treats them as `git-commit`: `#` comment lines and the post-scissors (`>8`) diff block are skipped automatically. Use both hooks together or pick the one that fits your workflow.
 
 To also scan source-code comments, extend the hook:
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
   "activationEvents": [
     "onLanguage:markdown",
     "onLanguage:plaintext",
+    "onLanguage:git-commit",
+    "onLanguage:scminput",
     "onStartupFinished"
   ],
   "main": "./out/extension.js",
@@ -117,6 +119,11 @@
           "type": "boolean",
           "default": false,
           "description": "Scan comments and docstrings in source code files for LLM slop. Off by default; enable to widen scanning beyond markdown and plaintext."
+        },
+        "llmSlopDetector.scanCommitMessages": {
+          "type": "boolean",
+          "default": true,
+          "description": "Scan Git commit editor buffers (git-commit) and VS Code's Source Control input box (scminput). On by default -- commit messages are short and findings are actionable. Turn off to silence diagnostics in those buffers."
         },
         "llmSlopDetector.codeCommentLanguages": {
           "type": "array",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,15 @@ const PROSE_EXTENSIONS = new Map<string, Language>([
   ['.text', 'plaintext'],
 ]);
 
+// Files git passes to commit-msg / prepare-commit-msg hooks, recognised by
+// basename so `llm-slop .git/COMMIT_EDITMSG` works without a flag.
+const GIT_MESSAGE_BASENAMES = new Map<string, Language>([
+  ['COMMIT_EDITMSG', 'git-commit'],
+  ['MERGE_MSG', 'git-commit'],
+  ['TAG_EDITMSG', 'git-commit'],
+  ['EDIT_DESCRIPTION', 'git-commit'],
+]);
+
 const CODE_EXTENSIONS = new Map<string, Language>([
   ['.ts', 'typescript'], ['.mts', 'typescript'], ['.cts', 'typescript'],
   ['.tsx', 'typescriptreact'],
@@ -179,7 +188,8 @@ function collectFiles(paths: string[], extensions: Map<string, Language>): strin
     }
     if (stat.isFile()) {
       const ext = path.extname(abs).toLowerCase();
-      if (extensions.has(ext)) {
+      const base = path.basename(abs);
+      if (extensions.has(ext) || GIT_MESSAGE_BASENAMES.has(base)) {
         result.push(abs);
       } else {
         process.stderr.write(`llm-slop: skipping ${p} (unrecognized extension; add --scan-comments for source code)\n`);
@@ -210,6 +220,8 @@ function walkDir(dir: string, extensions: Map<string, Language>, out: string[]):
 }
 
 function languageFor(file: string, extensions: Map<string, Language>): Language {
+  const byBasename = GIT_MESSAGE_BASENAMES.get(path.basename(file));
+  if (byBasename !== undefined) return byBasename;
   return extensions.get(path.extname(file).toLowerCase()) ?? 'plaintext';
 }
 

--- a/src/core/scan.ts
+++ b/src/core/scan.ts
@@ -81,13 +81,37 @@ export function scanText(text: string, rules: RuleSet, language: Language): Find
 // language isn't supported and the file should not be scanned at all.
 function computeExcludedRanges(text: string, language: Language): Range[] | null {
   if (language === 'markdown') return computeMarkdownExclusions(text);
-  if (language === 'plaintext') return [];
+  if (language === 'plaintext' || language === 'scminput') return [];
+  if (language === 'git-commit') return computeGitCommitExclusions(text);
 
   const commentScanner = getCommentScanner(language);
   if (commentScanner === null) return null;
 
   const comments = mergeRanges(commentScanner(text));
   return invertRanges(comments, text.length);
+}
+
+// Skip '#' comment lines (stripped by git before commit) and everything after
+// the verbose-commit scissors marker ("# ------------------------ >8 ---...").
+function computeGitCommitExclusions(text: string): Range[] {
+  const ranges: Range[] = [];
+  const scissorsRe = /^#\s*-+\s*>8\s*-+/;
+  let i = 0;
+  while (i <= text.length) {
+    const nl = text.indexOf('\n', i);
+    const lineEnd = nl === -1 ? text.length : nl;
+    const line = text.slice(i, lineEnd);
+    if (scissorsRe.test(line)) {
+      ranges.push([i, text.length]);
+      break;
+    }
+    if (line.startsWith('#')) {
+      ranges.push([i, nl === -1 ? text.length : nl + 1]);
+    }
+    if (nl === -1) break;
+    i = nl + 1;
+  }
+  return mergeRanges(ranges);
 }
 
 function invertRanges(ranges: Range[], textLen: number): Range[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,10 +14,12 @@ function rebuildSupportedLangs() {
   const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
   const scanComments = cfg.get<boolean>('scanCodeComments', false);
   const codeLangs = cfg.get<string[]>('codeCommentLanguages', []);
+  const scanCommitMessages = cfg.get<boolean>('scanCommitMessages', true);
   const allowed = new Set(SUPPORTED_CODE_LANGUAGES);
   SUPPORTED_LANGS = new Set<Language>([
     ...BASE_LANGS,
     ...(scanComments ? codeLangs.filter(l => allowed.has(l)) : []),
+    ...(scanCommitMessages ? ['git-commit', 'scminput'] : []),
   ]);
 }
 


### PR DESCRIPTION
Adds git-commit and scminput to the scanned language set so slop gets
flagged in .git/COMMIT_EDITMSG and VS Code's Source Control input box.
Gated on llmSlopDetector.scanCommitMessages (default true). In git-commit
buffers, '#' comment lines and everything below the verbose scissors
marker (------------------------ >8 ------------------------) are
skipped since git strips them before committing.

CLI recognises COMMIT_EDITMSG, MERGE_MSG, TAG_EDITMSG, and
EDIT_DESCRIPTION by basename and treats them as git-commit, so
'llm-slop .git/COMMIT_EDITMSG' works without a flag. A second
commit-msg-stage entry is added to .pre-commit-hooks.yaml.

Closes #40

https://claude.ai/code/session_011KBcsFVcZHC9Qvn6JWif8n