### PR TITLE
feat: ship JSON Schema for .llmsloprc.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Trust is granted per-workspace via VS Code's "Manage Workspace Trust" command. T
 
 ```json
 {
+  "$schema": "https://raw.githubusercontent.com/mandakan/llm-slop-detector/main/schemas/llmsloprc.schema.json",
   "name": "my-project",
   "version": "1.0.0",
   "description": "Extra phrases for this repo",
@@ -224,6 +225,8 @@ Each char rule: `char` required. `name`, `severity` (`error | warning | informat
 Each phrase rule: `pattern` required. `reason`, `severity` optional.
 
 Patterns are JavaScript regex, case-insensitive. Use `\\b` for word boundaries.
+
+The extension ships a JSON Schema and registers it via `contributes.jsonValidation`, so opening `.llmsloprc.json` in VS Code gives you key completion, hover docs, severity-enum suggestions, and red squigglies on unknown fields or wrong types. The `$schema` line above is optional (VS Code matches by filename) but makes the file self-describing for editors and tools outside VS Code.
 
 ### Quick user overrides (no rule file needed)
 

--- a/package.json
+++ b/package.json
@@ -151,6 +151,12 @@
         }
       }
     },
+    "jsonValidation": [
+      {
+        "fileMatch": [".llmsloprc.json", ".llmsloprc.jsonc"],
+        "url": "./schemas/llmsloprc.schema.json"
+      }
+    ],
     "commands": [
       {
         "command": "llmSlopDetector.toggle",

--- a/schemas/llmsloprc.schema.json
+++ b/schemas/llmsloprc.schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/mandakan/llm-slop-detector/blob/main/schemas/llmsloprc.schema.json",
+  "title": "LLM Slop Detector rule file",
+  "description": "Workspace-local rule overrides for the LLM Slop Detector VS Code extension and CLI. Drop this at the root of a workspace as .llmsloprc.json to add project-specific characters and phrases, or to override built-in rules. Patterns are JavaScript regex, compiled case-insensitive (gi). Later layers (local file, user settings) override earlier ones (built-in, packs) on the same char or pattern.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "URI of the JSON Schema for this file. Optional; VS Code picks the right schema automatically for .llmsloprc.json, but a $schema hint makes the file self-describing."
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for this rule source. Shown in the 'Show loaded rule sources' quick pick and in diagnostic messages as a [name] suffix. Defaults to the file path if omitted."
+    },
+    "version": {
+      "type": "string",
+      "description": "Optional version string for this rule source. Shown in the rule-sources quick pick."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional free-form description for this rule source."
+    },
+    "chars": {
+      "type": "array",
+      "description": "Character rules. Each entry flags a single character (typically invisible Unicode or AI-style punctuation) and can offer a quick-fix replacement.",
+      "items": { "$ref": "#/definitions/charRule" }
+    },
+    "phrases": {
+      "type": "array",
+      "description": "Phrase rules. Each entry is a JavaScript regex flagged on match. Compiled with 'gi' flags, so you do not need to write /.../gi -- just the body. Invalid regexes are skipped with a console warning rather than crashing the extension.",
+      "items": { "$ref": "#/definitions/phraseRule" }
+    }
+  },
+  "definitions": {
+    "severity": {
+      "type": "string",
+      "description": "Diagnostic severity. Maps to VS Code's Problems panel categories. Defaults: warning for invisible characters, information for visible punctuation and phrases.",
+      "enum": ["error", "warning", "information", "info", "hint"]
+    },
+    "charRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["char"],
+      "properties": {
+        "char": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The character to flag. Usually a single code point; the rule engine keys off the whole string, so paste the actual character (e.g. an em dash) rather than an escape sequence."
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable label for this character, used in diagnostic messages. Defaults to 'Unknown char (U+XXXX)' if omitted."
+        },
+        "severity": { "$ref": "#/definitions/severity" },
+        "replacement": {
+          "type": "string",
+          "description": "Text to substitute when the user accepts the quick fix. Omit to offer no deterministic fix. Use an empty string to delete the character outright (useful for zero-width invisibles)."
+        },
+        "suggestion": {
+          "type": "string",
+          "description": "Free-form advice shown in the diagnostic when there is no deterministic replacement. Typical use: explain why the character might be legitimate in some contexts (e.g. 'middle dot is valid in Catalan')."
+        }
+      }
+    },
+    "phraseRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pattern"],
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "minLength": 1,
+          "description": "JavaScript regular-expression source. Compiled with the 'gi' flags -- do not wrap in /.../ and do not add flags. Use \\\\b for word boundaries. Examples: '\\\\bdelve(s|d|ing)?\\\\b', '\\\\bnot only\\\\b.*\\\\bbut also\\\\b'. Invalid patterns are skipped with a console warning."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Short rationale shown in the diagnostic message. Examples: 'LLM filler', 'overused transition', 'banned in this repo'."
+        },
+        "severity": { "$ref": "#/definitions/severity" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add schemas/llmsloprc.schema.json (draft-07) and register it via
contributes.jsonValidation so VS Code provides key completion, hover
docs, and validation for .llmsloprc.json (and .llmsloprc.jsonc) in any
workspace. Adds a $schema hint to the README example for editors outside
VS Code.

Closes #36