### PR TITLE
feat: add .slopignore and llmSlopDetector.exclude for file-glob skips

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,14 @@
           },
           "description": "Override quick-fix replacements for specific characters. Key: the flagged character (e.g. \"—\" for em dash). Value: the replacement string. User overrides win over built-in and local-file rules."
         },
+        "llmSlopDetector.exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "File-glob patterns to skip, using .gitignore syntax. Merged with patterns from a .slopignore file at the workspace root. Example: [\"CHANGELOG.md\", \"docs/generated/**\"]. Use !pattern to re-include after a broader ignore."
+        },
         "llmSlopDetector.debounceMs": {
           "type": "number",
           "default": 150,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { parseArgs } from 'util';
 import { BUILTIN_PACKS, findLocalRulePathFromCwd, loadRules } from './core/rules';
 import { Finding, RuleSet, SEVERITY_RANK, Severity } from './core/types';
 import { Language, offsetToLineCol, scanText } from './core/scan';
+import { IgnoreMatcher, loadIgnoreMatcher } from './core/ignore';
 
 type Format = 'pretty' | 'json' | 'sarif';
 
@@ -17,6 +18,8 @@ type CliOptions = {
   severity: Severity;
   quiet: boolean;
   scanComments: boolean;
+  exclude: string[];
+  noIgnoreFile: boolean;
 };
 
 type FileReport = {
@@ -81,6 +84,9 @@ Options:
                                     information | hint (default: information)
       --scan-comments               Scan comments/docstrings in source code
                                     files (.ts, .py, .rs, .go, etc)
+      --exclude <pattern>            .gitignore-style pattern to skip. Repeat
+                                    for multiple. Merged with .slopignore.
+      --no-slopignore               Ignore the .slopignore file at cwd
   -q, --quiet                       Suppress the summary line
   -h, --help                        Show this help
   -v, --version                     Print version
@@ -105,6 +111,8 @@ function parseCli(argv: string[]): CliOptions {
       config: { type: 'string' },
       severity: { type: 'string', short: 's', default: 'information' },
       'scan-comments': { type: 'boolean', default: false },
+      exclude: { type: 'string', multiple: true, default: [] },
+      'no-slopignore': { type: 'boolean', default: false },
       quiet: { type: 'boolean', short: 'q', default: false },
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'v', default: false },
@@ -143,6 +151,11 @@ function parseCli(argv: string[]): CliOptions {
     die('no paths given. Try --help.');
   }
 
+  const excludeRaw = parsed.values.exclude;
+  const exclude = Array.isArray(excludeRaw)
+    ? excludeRaw.filter((v): v is string => typeof v === 'string')
+    : typeof excludeRaw === 'string' ? [excludeRaw] : [];
+
   return {
     paths: parsed.positionals,
     format: format as Format,
@@ -152,6 +165,8 @@ function parseCli(argv: string[]): CliOptions {
     severity: severityRaw as Severity,
     quiet: parsed.values.quiet as boolean,
     scanComments: parsed.values['scan-comments'] as boolean,
+    exclude,
+    noIgnoreFile: parsed.values['no-slopignore'] as boolean,
   };
 }
 
@@ -175,7 +190,12 @@ function extensionRoot(): string {
   return path.resolve(__dirname, '..');
 }
 
-function collectFiles(paths: string[], extensions: Map<string, Language>): string[] {
+function collectFiles(
+  paths: string[],
+  extensions: Map<string, Language>,
+  ignore: IgnoreMatcher,
+  ignoreRoot: string,
+): string[] {
   const result: string[] = [];
   for (const p of paths) {
     const abs = path.resolve(p);
@@ -190,18 +210,32 @@ function collectFiles(paths: string[], extensions: Map<string, Language>): strin
       const ext = path.extname(abs).toLowerCase();
       const base = path.basename(abs);
       if (extensions.has(ext) || GIT_MESSAGE_BASENAMES.has(base)) {
+        if (isIgnored(abs, ignoreRoot, ignore, false)) continue;
         result.push(abs);
       } else {
         process.stderr.write(`llm-slop: skipping ${p} (unrecognized extension; add --scan-comments for source code)\n`);
       }
     } else if (stat.isDirectory()) {
-      walkDir(abs, extensions, result);
+      walkDir(abs, extensions, result, ignore, ignoreRoot);
     }
   }
   return result;
 }
 
-function walkDir(dir: string, extensions: Map<string, Language>, out: string[]): void {
+function isIgnored(absPath: string, ignoreRoot: string, ignore: IgnoreMatcher, isDirectory: boolean): boolean {
+  if (ignore.patterns.length === 0) return false;
+  const rel = path.relative(ignoreRoot, absPath);
+  if (rel.length === 0 || rel.startsWith('..')) return false;
+  return ignore.ignores(rel, isDirectory);
+}
+
+function walkDir(
+  dir: string,
+  extensions: Map<string, Language>,
+  out: string[],
+  ignore: IgnoreMatcher,
+  ignoreRoot: string,
+): void {
   let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
@@ -212,8 +246,10 @@ function walkDir(dir: string, extensions: Map<string, Language>, out: string[]):
     if (e.name.startsWith('.') || e.name === 'node_modules' || e.name === 'out') continue;
     const full = path.join(dir, e.name);
     if (e.isDirectory()) {
-      walkDir(full, extensions, out);
+      if (isIgnored(full, ignoreRoot, ignore, true)) continue;
+      walkDir(full, extensions, out, ignore, ignoreRoot);
     } else if (e.isFile() && extensions.has(path.extname(e.name).toLowerCase())) {
+      if (isIgnored(full, ignoreRoot, ignore, false)) continue;
       out.push(full);
     }
   }
@@ -376,7 +412,10 @@ function main(): void {
     for (const [k, v] of CODE_EXTENSIONS) extensions.set(k, v);
   }
 
-  const files = collectFiles(opts.paths, extensions);
+  const ignoreRoot = process.cwd();
+  const ignore = loadIgnoreMatcher(opts.noIgnoreFile ? null : ignoreRoot, opts.exclude);
+
+  const files = collectFiles(opts.paths, extensions, ignore, ignoreRoot);
   const reports: FileReport[] = files.map(f => ({ path: f, findings: scanFile(f, rules, extensions) }));
 
   let output: string;

--- a/src/core/ignore.ts
+++ b/src/core/ignore.ts
@@ -1,0 +1,129 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const SLOPIGNORE_FILENAME = '.slopignore';
+
+type IgnorePattern = {
+  raw: string;
+  negate: boolean;
+  dirOnly: boolean;
+  regex: RegExp;
+};
+
+export type IgnoreMatcher = {
+  patterns: IgnorePattern[];
+  ignores(relPath: string, isDirectory?: boolean): boolean;
+};
+
+// Parse .gitignore-style pattern lines into matchers. Blank lines and lines
+// starting with `#` are skipped. `!foo` negates; trailing `/` means
+// directory-only; a leading `/` or an internal `/` anchors to the root; a bare
+// name matches at any depth.
+export function parseIgnorePatterns(lines: string[]): IgnorePattern[] {
+  const out: IgnorePattern[] = [];
+  for (const rawLine of lines) {
+    let line = rawLine.replace(/\r$/, '');
+    // Strip unescaped trailing whitespace. `\ ` preserves a trailing space.
+    line = line.replace(/(?:^|[^\\])\s+$/, m => {
+      const first = m[0];
+      return first === ' ' || first === '\t' ? '' : first;
+    });
+    if (line.length === 0) continue;
+    if (line.startsWith('#')) continue;
+    if (line.startsWith('\\#')) line = line.slice(1);
+
+    let negate = false;
+    if (line.startsWith('!')) { negate = true; line = line.slice(1); }
+
+    let dirOnly = false;
+    if (line.endsWith('/')) { dirOnly = true; line = line.slice(0, -1); }
+    if (line.length === 0) continue;
+
+    let rooted: boolean;
+    if (line.startsWith('/')) { rooted = true; line = line.slice(1); }
+    else { rooted = line.includes('/'); }
+
+    const regex = globToRegex(line, rooted);
+    out.push({ raw: rawLine, negate, dirOnly, regex });
+  }
+  return out;
+}
+
+function escapeRegexChar(c: string): string {
+  return /[.+^${}()|[\]\\/]/.test(c) ? '\\' + c : c;
+}
+
+function globToRegex(pattern: string, rooted: boolean): RegExp {
+  let re = '';
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i];
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        if (pattern[i + 2] === '/') { re += '(?:.*/)?'; i += 3; continue; }
+        re += '.*'; i += 2; continue;
+      }
+      re += '[^/]*'; i++; continue;
+    }
+    if (c === '?') { re += '[^/]'; i++; continue; }
+    if (c === '[') {
+      const j = pattern.indexOf(']', i + 1);
+      if (j !== -1) { re += pattern.slice(i, j + 1); i = j + 1; continue; }
+      re += '\\['; i++; continue;
+    }
+    if (c === '\\' && i + 1 < pattern.length) {
+      re += escapeRegexChar(pattern[i + 1]);
+      i += 2;
+      continue;
+    }
+    re += escapeRegexChar(c);
+    i++;
+  }
+  const prefix = rooted ? '^' : '^(?:.*/)?';
+  // Trailing "(?:/.*)?$" lets a directory pattern ("docs" or "docs/") match
+  // every descendant without a second pass.
+  const suffix = '(?:/.*)?$';
+  return new RegExp(prefix + re + suffix);
+}
+
+function toPosix(p: string): string {
+  return p.replace(/\\/g, '/').replace(/^\.\//, '').replace(/^\//, '');
+}
+
+export function buildIgnoreMatcher(patterns: IgnorePattern[]): IgnoreMatcher {
+  return {
+    patterns,
+    ignores(relPath: string, isDirectory?: boolean): boolean {
+      const normalized = toPosix(relPath);
+      if (normalized.length === 0) return false;
+      let ignored = false;
+      for (const p of patterns) {
+        if (p.dirOnly && isDirectory === false) continue;
+        if (p.regex.test(normalized)) {
+          ignored = !p.negate;
+        }
+      }
+      return ignored;
+    },
+  };
+}
+
+export function loadIgnoreMatcher(
+  rootDir: string | null,
+  extraPatterns: string[] = [],
+): IgnoreMatcher {
+  const lines: string[] = [];
+  if (rootDir !== null) {
+    const file = path.join(rootDir, SLOPIGNORE_FILENAME);
+    try {
+      const text = fs.readFileSync(file, 'utf8');
+      lines.push(...text.split(/\r?\n/));
+    } catch {
+      // No .slopignore present -- fall through to just the extra patterns.
+    }
+  }
+  for (const p of extraPatterns) {
+    if (typeof p === 'string') lines.push(p);
+  }
+  return buildIgnoreMatcher(parseIgnorePatterns(lines));
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import { LOCAL_RULES_FILENAME, RuleSet, loadRules, severityToVscode } from './rules';
 import { Language, scanText } from './core/scan';
 import { SUPPORTED_CODE_LANGUAGES } from './core/comments';
+import { IgnoreMatcher, SLOPIGNORE_FILENAME, loadIgnoreMatcher } from './core/ignore';
 import { Finding } from './core/types';
 
 const SOURCE = 'LLM Slop';
@@ -26,6 +28,22 @@ function rebuildSupportedLangs() {
 // Module-level mutable rule state. Rebuilt on config change / rule-file change
 // and scans read through it.
 let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(?!)/g };
+
+// One ignore matcher per workspace folder. Rebuilt on config change or when a
+// .slopignore file is created/changed/deleted. Untitled and out-of-workspace
+// docs bypass ignore filtering.
+let IGNORE_BY_FOLDER = new Map<string, IgnoreMatcher>();
+
+function isIgnoredDocument(doc: vscode.TextDocument): boolean {
+  if (doc.uri.scheme !== 'file') return false;
+  const folder = vscode.workspace.getWorkspaceFolder(doc.uri);
+  if (!folder) return false;
+  const matcher = IGNORE_BY_FOLDER.get(folder.uri.fsPath);
+  if (!matcher || matcher.patterns.length === 0) return false;
+  const rel = path.relative(folder.uri.fsPath, doc.uri.fsPath);
+  if (rel.startsWith('..')) return false;
+  return matcher.ignores(rel);
+}
 
 // Findings keyed by document URI, stashed during scan so the hover provider
 // can recover rule metadata (pattern, matched char) without rescanning.
@@ -191,8 +209,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   const refresh = (doc: vscode.TextDocument) => {
     const enabled = vscode.workspace.getConfiguration('llmSlopDetector').get<boolean>('enabled', true);
-    if (!enabled || !SUPPORTED_LANGS.has(doc.languageId as Language)) {
+    if (!enabled || !SUPPORTED_LANGS.has(doc.languageId as Language) || isIgnoredDocument(doc)) {
       collection.delete(doc.uri);
+      FINDINGS_BY_URI.delete(doc.uri.toString());
       return;
     }
     collection.set(doc.uri, scanDocument(doc));
@@ -234,7 +253,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const updateStatus = () => {
     const editor = vscode.window.activeTextEditor;
-    if (!editor || !SUPPORTED_LANGS.has(editor.document.languageId as Language)) {
+    if (!editor || !SUPPORTED_LANGS.has(editor.document.languageId as Language) || isIgnoredDocument(editor.document)) {
       status.hide();
       return;
     }
@@ -265,8 +284,19 @@ export function activate(context: vscode.ExtensionContext) {
     status.show();
   };
 
+  const reloadIgnore = () => {
+    const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
+    const extra = cfg.get<string[]>('exclude', []);
+    const next = new Map<string, IgnoreMatcher>();
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      next.set(folder.uri.fsPath, loadIgnoreMatcher(folder.uri.fsPath, extra));
+    }
+    IGNORE_BY_FOLDER = next;
+  };
+
   const reloadRules = () => {
     RULES = loadRules(context.extensionUri);
+    reloadIgnore();
     rebuildSupportedLangs();
     vscode.workspace.textDocuments.forEach(refresh);
     updateStatus();
@@ -278,11 +308,16 @@ export function activate(context: vscode.ExtensionContext) {
   // anywhere in the workspace. The loader itself only reads the files at
   // workspace roots; nested matches just trigger a harmless reload.
   const watcher = vscode.workspace.createFileSystemWatcher(`**/${LOCAL_RULES_FILENAME}`);
+  const ignoreWatcher = vscode.workspace.createFileSystemWatcher(`**/${SLOPIGNORE_FILENAME}`);
   context.subscriptions.push(
     watcher,
     watcher.onDidChange(reloadRules),
     watcher.onDidCreate(reloadRules),
     watcher.onDidDelete(reloadRules),
+    ignoreWatcher,
+    ignoreWatcher.onDidChange(reloadRules),
+    ignoreWatcher.onDidCreate(reloadRules),
+    ignoreWatcher.onDidDelete(reloadRules),
   );
 
   context.subscriptions.push(


### PR DESCRIPTION
Closes #38.

A .slopignore file at the workspace root (gitignore syntax: blank/#
comments, bare names match at any depth, trailing / is dir, leading or
internal / anchors to root, ! negates last-match-wins) plus an additive
llmSlopDetector.exclude setting let users skip CHANGELOG.md, generated
docs, vendored subtrees, etc.

Extension: one IgnoreMatcher per workspace folder, rebuilt on config
change or .slopignore create/change/delete via a second file watcher.
refresh() clears diagnostics for now-excluded docs and the status bar
hides on them. CLI: prunes walkDir descents, filters explicit file paths
(so the pre-commit hook skips excluded files too), and exposes --exclude
/ --no-slopignore. New src/core/ignore.ts is a ~150-LOC hand-rolled
matcher with no new runtime deps.