### PR TITLE
feat: add llmSlopDetector.severityOverrides for per-rule tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,41 @@ Attribution and license texts for each pack's source are in [`THIRD_PARTY_NOTICE
 
 ### Tuning a pack
 
-Packs are merged after the core list, so a pack entry wins if it targets the same char as core. Phrase rules accumulate. If a specific pack rule is too noisy for your writing, either:
-
-1. Disable the whole pack (remove from `enabledPacks`), or
-2. Keep the pack enabled and override locally via a `.llmsloprc.json` file at your workspace root -- a later layer's chars override earlier layers on the same character; phrases are additive, so there's no way to silence a single phrase without forking the pack.
+Packs are merged after the core list, so a pack entry wins if it targets the same char as core. Phrase rules accumulate. If a specific pack rule is too noisy for your writing, use `llmSlopDetector.severityOverrides` (see [Severity overrides](#severity-overrides)) to downgrade or disable it from one place, without forking the pack.
 
 If a whole pack is unusable in your workflow, file an issue.
+
+## Severity overrides
+
+`llmSlopDetector.severityOverrides` is a map from a rule selector to a severity level (or `off` to disable the rule entirely). Use it to downgrade a noisy pack, silence one rule, or promote a source that matters more in your repo -- all from a single setting, no fork needed.
+
+```json
+"llmSlopDetector.severityOverrides": {
+  "pack:academic": "hint",
+  "phrase:\\bdelve(s|d|ing)?\\b": "off",
+  "char:U+2014": "information",
+  "source:built-in": "warning"
+}
+```
+
+Selectors (same shape as the inline-ignore directive specs):
+
+- `pack:<name>` -- every rule from a built-in pack (`pack:academic`, `pack:cliches`, etc.)
+- `phrase:<pattern>` -- matches a phrase rule's `pattern` field exactly. Hover over a flagged phrase to copy its pattern.
+- `char:<literal>` or `char:U+XXXX` -- matches a char rule by literal or codepoint.
+- `source:<name>` -- matches `RuleSource.name` (`built-in`, `pack:academic`, `user settings`, or the `name` field from your `.llmsloprc.json`).
+
+Values: `error`, `warning`, `information`, `hint`, or `off`. Invalid values are dropped with a console warning.
+
+Precedence: most-specific wins. `phrase:` / `char:` beats `pack:`, which beats `source:`. If two selectors of the same specificity both match (for example `char:—` and `char:U+2014`), the literal form wins.
+
+The CLI takes the same settings via a repeatable `--severity-override key=value`:
+
+```bash
+llm-slop --severity-override pack:academic=hint --severity-override 'phrase:\bdelve(s|d|ing)?\b=off' README.md
+```
+
+The "Show loaded rule sources" command reports how many rules were affected by overrides on a trailing line.
 
 ## Configuration
 
@@ -193,6 +222,8 @@ Rules merge from these layers (later overrides earlier on the same char or patte
 2. Optional built-in packs listed in `llmSlopDetector.enabledPacks`
 3. Local `.llmsloprc.json` in a workspace folder's root (auto-loaded, live-reloaded). Skipped in untrusted workspaces -- see [Workspace trust](#workspace-trust).
 4. User settings
+
+After merging, `llmSlopDetector.severityOverrides` is applied -- it can downgrade or disable any rule from any layer without editing the source. See [Severity overrides](#severity-overrides).
 
 ### Workspace trust
 
@@ -252,6 +283,7 @@ Options:
 - `--no-builtin` -- skip the built-in core rule list
 - `--config <path>` -- explicit `.llmsloprc.json` path (default: nearest ancestor of cwd)
 - `-s, --severity <level>` -- fail threshold: `error | warning | information | hint` (default `information`)
+- `--severity-override <selector>=<level>` -- override severity for a selector (see [Severity overrides](#severity-overrides)). Repeatable. Level may be `off` to disable.
 - `--scan-comments` -- also scan comments and docstrings in source code files (`.ts`, `.py`, `.rs`, etc). Off by default.
 - `-q, --quiet` -- suppress the summary line
 - `-h, --help` / `-v, --version`

--- a/package.json
+++ b/package.json
@@ -108,6 +108,15 @@
           },
           "description": "Override quick-fix replacements for specific characters. Key: the flagged character (e.g. \"—\" for em dash). Value: the replacement string. User overrides win over built-in and local-file rules."
         },
+        "llmSlopDetector.severityOverrides": {
+          "type": "object",
+          "default": {},
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["error", "warning", "information", "hint", "off"]
+          },
+          "description": "Override severity for specific rules, packs, or sources. Selector keys: pack:<name> (e.g. pack:academic), phrase:<exact-pattern>, char:<literal> or char:U+XXXX, source:<name>. Values: error | warning | information | hint | off (off disables the rule entirely). Precedence: phrase/char > pack > source -- most specific wins. Example: {\"pack:academic\": \"hint\", \"phrase:\\\\bdelve(s|d|ing)?\\\\b\": \"off\"}."
+        },
         "llmSlopDetector.exclude": {
           "type": "array",
           "items": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,8 +2,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { parseArgs } from 'util';
-import { BUILTIN_PACKS, findLocalRulePathFromCwd, loadRules } from './core/rules';
-import { Finding, RuleSet, SEVERITY_RANK, Severity } from './core/types';
+import { BUILTIN_PACKS, findLocalRulePathFromCwd, loadRules, parseSeverityOverrides } from './core/rules';
+import { Finding, RuleSet, SEVERITY_RANK, Severity, SeverityOverride } from './core/types';
 import { Language, offsetToLineCol, scanText } from './core/scan';
 import { IgnoreMatcher, loadIgnoreMatcher } from './core/ignore';
 
@@ -20,6 +20,7 @@ type CliOptions = {
   scanComments: boolean;
   exclude: string[];
   noIgnoreFile: boolean;
+  severityOverrides: Record<string, SeverityOverride>;
 };
 
 type FileReport = {
@@ -87,6 +88,12 @@ Options:
       --exclude <pattern>            .gitignore-style pattern to skip. Repeat
                                     for multiple. Merged with .slopignore.
       --no-slopignore               Ignore the .slopignore file at cwd
+      --severity-override <k=v>     Override severity for a selector. Repeat
+                                    for multiple. Value: error | warning |
+                                    information | hint | off.
+                                    Selectors: pack:<name>,
+                                    phrase:<pattern>, char:<literal|U+XXXX>,
+                                    source:<name>.
   -q, --quiet                       Suppress the summary line
   -h, --help                        Show this help
   -v, --version                     Print version
@@ -113,6 +120,7 @@ function parseCli(argv: string[]): CliOptions {
       'scan-comments': { type: 'boolean', default: false },
       exclude: { type: 'string', multiple: true, default: [] },
       'no-slopignore': { type: 'boolean', default: false },
+      'severity-override': { type: 'string', multiple: true, default: [] },
       quiet: { type: 'boolean', short: 'q', default: false },
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'v', default: false },
@@ -156,6 +164,25 @@ function parseCli(argv: string[]): CliOptions {
     ? excludeRaw.filter((v): v is string => typeof v === 'string')
     : typeof excludeRaw === 'string' ? [excludeRaw] : [];
 
+  const overrideRaw = parsed.values['severity-override'];
+  const overrideSpecs = Array.isArray(overrideRaw)
+    ? overrideRaw.filter((v): v is string => typeof v === 'string')
+    : typeof overrideRaw === 'string' ? [overrideRaw] : [];
+  const rawOverrides: Record<string, unknown> = {};
+  const validValues = new Set(['error', 'warning', 'information', 'info', 'hint', 'off']);
+  for (const spec of overrideSpecs) {
+    const eq = spec.indexOf('=');
+    if (eq === -1) die(`invalid --severity-override: ${spec} (expected key=value)`);
+    const key = spec.slice(0, eq).trim();
+    const value = spec.slice(eq + 1).trim();
+    if (key.length === 0) die(`invalid --severity-override: ${spec} (empty selector)`);
+    if (!validValues.has(value)) {
+      die(`invalid --severity-override value: ${spec} (expected error|warning|information|hint|off)`);
+    }
+    rawOverrides[key] = value;
+  }
+  const severityOverrides = parseSeverityOverrides(rawOverrides);
+
   return {
     paths: parsed.positionals,
     format: format as Format,
@@ -167,8 +194,10 @@ function parseCli(argv: string[]): CliOptions {
     scanComments: parsed.values['scan-comments'] as boolean,
     exclude,
     noIgnoreFile: parsed.values['no-slopignore'] as boolean,
+    severityOverrides,
   };
 }
+
 
 function die(msg: string): never {
   process.stderr.write(`llm-slop: ${msg}\n`);
@@ -405,6 +434,7 @@ function main(): void {
     localRulePaths,
     userPhrases: [],
     charReplacements: {},
+    severityOverrides: opts.severityOverrides,
   });
 
   const extensions = new Map<string, Language>(PROSE_EXTENSIONS);

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { CharRule, RuleSet, Severity } from './types';
+import { CharRule, PhraseRule, RuleSet, Severity, SeverityOverride } from './types';
 
 export const LOCAL_RULES_FILENAME = '.llmsloprc.json';
 
@@ -14,6 +14,7 @@ export type LoadOptions = {
   localRulePaths: string[];
   userPhrases: string[];
   charReplacements: Record<string, string>;
+  severityOverrides: Record<string, SeverityOverride>;
 };
 
 type RawCharRule = {
@@ -144,12 +145,133 @@ function buildCharRegex(chars: Map<string, CharRule>): RegExp {
   return new RegExp('[' + body + ']', 'gu');
 }
 
+function charCodepointSelector(char: string): string {
+  return `char:U+${char.codePointAt(0)!.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+// Normalize `char:u+2014` / `char:U+2014` / `char:U+02014` to a single canonical
+// key so lookups don't depend on user casing or zero-padding. Literal char keys
+// (`char:—`) and non-char selectors pass through unchanged.
+function normalizeOverrideKey(key: string): string {
+  if (!key.startsWith('char:')) return key;
+  const rest = key.slice(5);
+  const m = /^[uU]\+([0-9a-fA-F]+)$/.exec(rest);
+  if (!m) return key;
+  const cp = parseInt(m[1], 16);
+  if (Number.isNaN(cp)) return key;
+  return `char:U+${cp.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+function parseSeverityOverrideValue(v: unknown): SeverityOverride | null {
+  if (v === 'off') return 'off';
+  if (v === 'error' || v === 'warning' || v === 'hint') return v;
+  if (v === 'information' || v === 'info') return 'information';
+  return null;
+}
+
+// Canonicalize user-provided override map: normalize char selector keys and
+// validate/coerce values. Invalid values are dropped with a console warning.
+export function parseSeverityOverrides(raw: Record<string, unknown> | undefined | null): Record<string, SeverityOverride> {
+  if (!raw || typeof raw !== 'object') return {};
+  const out: Record<string, SeverityOverride> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const parsed = parseSeverityOverrideValue(value);
+    if (parsed === null) {
+      console.warn(`[LLM Slop] invalid severity in severityOverrides for "${key}": ${String(value)}`);
+      continue;
+    }
+    out[normalizeOverrideKey(key)] = parsed;
+  }
+  return out;
+}
+
+function resolveCharOverride(
+  rule: CharRule,
+  overrides: Record<string, SeverityOverride>,
+): SeverityOverride | undefined {
+  // Most specific: rule-level. Literal first so `char:—: hint` beats
+  // `char:U+2014: off` when both are present.
+  const literal = `char:${rule.char}`;
+  if (literal in overrides) return overrides[literal];
+  const cp = charCodepointSelector(rule.char);
+  if (cp in overrides) return overrides[cp];
+  // Pack-level (source is `pack:<name>` for built-in packs).
+  if (rule.source.startsWith('pack:') && rule.source in overrides) return overrides[rule.source];
+  // Source-level.
+  const src = `source:${rule.source}`;
+  if (src in overrides) return overrides[src];
+  return undefined;
+}
+
+function resolvePhraseOverride(
+  rule: PhraseRule,
+  overrides: Record<string, SeverityOverride>,
+): SeverityOverride | undefined {
+  const phraseKey = `phrase:${rule.pattern}`;
+  if (phraseKey in overrides) return overrides[phraseKey];
+  if (rule.source.startsWith('pack:') && rule.source in overrides) return overrides[rule.source];
+  const src = `source:${rule.source}`;
+  if (src in overrides) return overrides[src];
+  return undefined;
+}
+
+function applySeverityOverrides(
+  rules: RuleSet,
+  overrides: Record<string, SeverityOverride>,
+): void {
+  if (Object.keys(overrides).length === 0) return;
+
+  let applied = 0;
+
+  const charsToDelete: string[] = [];
+  for (const [char, rule] of rules.chars) {
+    const ov = resolveCharOverride(rule, overrides);
+    if (ov === undefined) continue;
+    applied++;
+    if (ov === 'off') charsToDelete.push(char);
+    else rules.chars.set(char, { ...rule, severity: ov });
+  }
+  for (const c of charsToDelete) rules.chars.delete(c);
+
+  const remainingPhrases: PhraseRule[] = [];
+  for (const phrase of rules.phrases) {
+    const ov = resolvePhraseOverride(phrase, overrides);
+    if (ov === undefined) {
+      remainingPhrases.push(phrase);
+      continue;
+    }
+    applied++;
+    if (ov === 'off') continue;
+    remainingPhrases.push({ ...phrase, severity: ov });
+  }
+  rules.phrases = remainingPhrases;
+
+  // Recompute per-source counts so the rule-sources quick pick reflects
+  // effective rule counts rather than raw ingest counts.
+  const countBySource = new Map<string, { chars: number; phrases: number }>();
+  const bump = (name: string, kind: 'chars' | 'phrases') => {
+    const entry = countBySource.get(name) ?? { chars: 0, phrases: 0 };
+    entry[kind]++;
+    countBySource.set(name, entry);
+  };
+  for (const r of rules.chars.values()) bump(r.source, 'chars');
+  for (const r of rules.phrases) bump(r.source, 'phrases');
+  for (const src of rules.sources) {
+    const c = countBySource.get(src.name);
+    src.charCount = c?.chars ?? 0;
+    src.phraseCount = c?.phrases ?? 0;
+  }
+
+  rules.overridesApplied = applied;
+}
+
 export function loadRules(opts: LoadOptions): RuleSet {
   const rules: RuleSet = {
     chars: new Map(),
     phrases: [],
     sources: [],
     charRegex: /(?!)/g,
+    overridesApplied: 0,
   };
 
   if (opts.useBuiltin) {
@@ -197,6 +319,8 @@ export function loadRules(opts: LoadOptions): RuleSet {
       });
     }
   }
+
+  applySeverityOverrides(rules, opts.severityOverrides);
 
   rules.charRegex = buildCharRegex(rules.chars);
   return rules;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,5 +1,7 @@
 export type Severity = 'error' | 'warning' | 'information' | 'hint';
 
+export type SeverityOverride = Severity | 'off';
+
 export const SEVERITY_RANK: Record<Severity, number> = {
   error: 0,
   warning: 1,
@@ -38,6 +40,7 @@ export type RuleSet = {
   phrases: PhraseRule[];
   sources: RuleSource[];
   charRegex: RegExp;
+  overridesApplied: number;
 };
 
 export type Finding = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ function rebuildSupportedLangs() {
 
 // Module-level mutable rule state. Rebuilt on config change / rule-file change
 // and scans read through it.
-let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(?!)/g };
+let RULES: RuleSet = { chars: new Map(), phrases: [], sources: [], charRegex: /(?!)/g, overridesApplied: 0 };
 
 // One ignore matcher per workspace folder. Rebuilt on config change or when a
 // .slopignore file is created/changed/deleted. Untitled and out-of-workspace
@@ -362,11 +362,17 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showInformationMessage('LLM Slop Detector: no rule sources loaded.');
         return;
       }
-      const items = RULES.sources.map(s => ({
+      const items: vscode.QuickPickItem[] = RULES.sources.map(s => ({
         label: `$(list-unordered) ${s.name}${s.version ? ` v${s.version}` : ''}`,
         description: `${s.charCount} char${s.charCount === 1 ? '' : 's'}, ${s.phraseCount} phrase${s.phraseCount === 1 ? '' : 's'}`,
         detail: s.description ? `${s.description} (${s.origin})` : s.origin,
       }));
+      if (RULES.overridesApplied > 0) {
+        items.push({
+          label: `$(settings-gear) ${RULES.overridesApplied} severity override${RULES.overridesApplied === 1 ? '' : 's'} applied`,
+          description: 'via llmSlopDetector.severityOverrides',
+        });
+      }
       await vscode.window.showQuickPick(items, { title: 'LLM Slop Detector: loaded rule sources' });
     })
   );

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
-import { BUILTIN_PACKS, LOCAL_RULES_FILENAME, loadRules as coreLoadRules } from './core/rules';
+import { BUILTIN_PACKS, LOCAL_RULES_FILENAME, loadRules as coreLoadRules, parseSeverityOverrides } from './core/rules';
 import { RuleSet, Severity } from './core/types';
 
 export { LOCAL_RULES_FILENAME, BUILTIN_PACKS };
@@ -38,5 +38,6 @@ export function loadRules(extensionUri: vscode.Uri): RuleSet {
     localRulePaths: getLocalRulePaths(),
     userPhrases: cfg.get<string[]>('phrases', []),
     charReplacements: cfg.get<Record<string, string>>('charReplacements', {}),
+    severityOverrides: parseSeverityOverrides(cfg.get<Record<string, unknown>>('severityOverrides', {})),
   });
 }


### PR DESCRIPTION
Lets users downgrade a noisy pack, silence one rule, or promote a source
without forking .llmsloprc.json. Selectors mirror inline-ignore directives:
pack:<name>, phrase:<pattern>, char:<literal|U+XXXX>, source:<name>. Values
are error | warning | information | hint | off. Precedence: most-specific
wins (phrase/char > pack > source).

Also exposes --severity-override on the CLI and reports the number of
affected rules on the "Show loaded rule sources" quick pick.

Closes #37

https://claude.ai/code/session_01W541N4s7Sewu5Hn8Dqe494