### PR TITLE
feat: add Scan workspace command

### DIFF
--- a/.slopignore
+++ b/.slopignore
@@ -1,0 +1,1 @@
+test-fixtures

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,10 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "${workspaceFolder}/test-fixtures",
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
       "outFiles": ["${workspaceFolder}/out/**/*.js"],
       "preLaunchTask": "npm: watch"
     }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,7 +4,9 @@
 .claude/**
 docs/**
 src/**
+test-fixtures/**
 .gitignore
+.slopignore
 .vscodeignore
 tsconfig.json
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -204,6 +204,10 @@
       {
         "command": "llmSlopDetector.scanSelection",
         "title": "LLM Slop Detector: Scan selection"
+      },
+      {
+        "command": "llmSlopDetector.scanWorkspace",
+        "title": "LLM Slop Detector: Scan workspace"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,53 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
+import * as fsp from 'fs/promises';
 import { LOCAL_RULES_FILENAME, RuleSet, loadRules, severityToVscode } from './rules';
-import { Language, scanText } from './core/scan';
+import { Language, offsetToLineCol, scanText } from './core/scan';
 import { SUPPORTED_CODE_LANGUAGES } from './core/comments';
 import { IgnoreMatcher, SLOPIGNORE_FILENAME, loadIgnoreMatcher } from './core/ignore';
-import { Finding } from './core/types';
+import { Finding, Severity } from './core/types';
 
 const SOURCE = 'LLM Slop';
 const DOCS_URI = vscode.Uri.parse('https://github.com/mandakan/llm-slop-detector#what-it-flags');
 const BASE_LANGS: Language[] = ['markdown', 'plaintext'];
 let SUPPORTED_LANGS = new Set<Language>(BASE_LANGS);
 const CODE_ACTION_SELECTORS: vscode.DocumentSelector = [{ scheme: 'file' }, { scheme: 'untitled' }];
+
+// File-extension to language mapping for closed files. Mirrors the CLI; the
+// extension uses VS Code's language IDs for open documents but needs an
+// extension-based fallback for the workspace scan, which reads files off disk.
+const PROSE_EXTENSIONS: ReadonlyMap<string, Language> = new Map([
+  ['.md', 'markdown'],
+  ['.markdown', 'markdown'],
+  ['.mdown', 'markdown'],
+  ['.txt', 'plaintext'],
+  ['.text', 'plaintext'],
+]);
+
+const CODE_EXTENSIONS: ReadonlyMap<string, Language> = new Map([
+  ['.ts', 'typescript'], ['.mts', 'typescript'], ['.cts', 'typescript'],
+  ['.tsx', 'typescriptreact'],
+  ['.js', 'javascript'], ['.mjs', 'javascript'], ['.cjs', 'javascript'],
+  ['.jsx', 'javascriptreact'],
+  ['.py', 'python'],
+  ['.rs', 'rust'],
+  ['.go', 'go'],
+  ['.java', 'java'],
+  ['.cs', 'csharp'],
+  ['.cpp', 'cpp'], ['.cxx', 'cpp'], ['.cc', 'cpp'], ['.hpp', 'cpp'], ['.hxx', 'cpp'],
+  ['.c', 'c'], ['.h', 'c'],
+  ['.rb', 'ruby'],
+  ['.php', 'php'],
+  ['.sh', 'shellscript'], ['.bash', 'shellscript'], ['.zsh', 'shellscript'],
+  ['.swift', 'swift'],
+  ['.kt', 'kotlin'], ['.kts', 'kotlin'],
+  ['.scala', 'scala'], ['.sc', 'scala'],
+  ['.dart', 'dart'],
+  ['.pl', 'perl'], ['.pm', 'perl'],
+  ['.r', 'r'],
+  ['.yaml', 'yaml'], ['.yml', 'yaml'],
+]);
 
 function rebuildSupportedLangs() {
   const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
@@ -357,6 +394,7 @@ export function activate(context: vscode.ExtensionContext) {
     }),
     vscode.commands.registerCommand('llmSlopDetector.showOnboarding', () => showOnboarding(context)),
     vscode.commands.registerCommand('llmSlopDetector.scanSelection', () => scanSelection()),
+    vscode.commands.registerCommand('llmSlopDetector.scanWorkspace', () => scanWorkspace()),
     vscode.commands.registerCommand('llmSlopDetector.showRuleSources', async () => {
       if (RULES.sources.length === 0) {
         vscode.window.showInformationMessage('LLM Slop Detector: no rule sources loaded.');
@@ -441,6 +479,197 @@ async function scanSelection(): Promise<void> {
     editor.revealRange(pick.diagnostic.range, vscode.TextEditorRevealType.InCenter);
     editor.selection = new vscode.Selection(pick.diagnostic.range.start, pick.diagnostic.range.end);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Scan workspace
+// ---------------------------------------------------------------------------
+
+type WorkspaceHit = {
+  uri: vscode.Uri;
+  relPath: string;
+  finding: Finding;
+  displayLine: number;
+  displayCol: number;
+};
+
+function buildScanExtensionMap(): Map<string, Language> {
+  const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
+  const out = new Map<string, Language>(PROSE_EXTENSIONS);
+  if (cfg.get<boolean>('scanCodeComments', false)) {
+    const allowed = new Set(SUPPORTED_CODE_LANGUAGES);
+    const enabled = new Set(cfg.get<string[]>('codeCommentLanguages', []).filter(l => allowed.has(l)));
+    for (const [ext, lang] of CODE_EXTENSIONS) {
+      if (enabled.has(lang)) out.set(ext, lang);
+    }
+  }
+  return out;
+}
+
+function walkWorkspaceFolder(
+  rootDir: string,
+  currentDir: string,
+  extensions: ReadonlyMap<string, Language>,
+  ignore: IgnoreMatcher | undefined,
+  push: (absPath: string, lang: Language) => void,
+  token: vscode.CancellationToken,
+): void {
+  if (token.isCancellationRequested) return;
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(currentDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    if (token.isCancellationRequested) return;
+    // Same hard-coded skips as the CLI walker: dotfiles, node_modules, build out.
+    if (e.name.startsWith('.') || e.name === 'node_modules' || e.name === 'out') continue;
+    const full = path.join(currentDir, e.name);
+    const rel = path.relative(rootDir, full);
+    if (e.isDirectory()) {
+      if (ignore && ignore.patterns.length > 0 && ignore.ignores(rel, true)) continue;
+      walkWorkspaceFolder(rootDir, full, extensions, ignore, push, token);
+    } else if (e.isFile()) {
+      const lang = extensions.get(path.extname(e.name).toLowerCase());
+      if (lang === undefined) continue;
+      if (ignore && ignore.patterns.length > 0 && ignore.ignores(rel, false)) continue;
+      push(full, lang);
+    }
+  }
+}
+
+async function scanWorkspace(): Promise<void> {
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length === 0) {
+    vscode.window.showInformationMessage('LLM Slop Detector: open a folder to scan the workspace.');
+    return;
+  }
+  const cfg = vscode.workspace.getConfiguration('llmSlopDetector');
+  if (!cfg.get<boolean>('enabled', true)) {
+    vscode.window.showInformationMessage('LLM Slop Detector is disabled. Enable it before scanning.');
+    return;
+  }
+
+  const extensions = buildScanExtensionMap();
+
+  type Target = { absPath: string; uri: vscode.Uri; lang: Language; relPath: string };
+
+  const hits = await vscode.window.withProgress<WorkspaceHit[] | undefined>({
+    location: vscode.ProgressLocation.Notification,
+    title: 'LLM Slop Detector: scanning workspace',
+    cancellable: true,
+  }, async (progress, token) => {
+    const targets: Target[] = [];
+    for (const folder of folders) {
+      if (token.isCancellationRequested) return undefined;
+      const matcher = IGNORE_BY_FOLDER.get(folder.uri.fsPath);
+      walkWorkspaceFolder(folder.uri.fsPath, folder.uri.fsPath, extensions, matcher, (absPath, lang) => {
+        targets.push({
+          absPath,
+          uri: vscode.Uri.file(absPath),
+          lang,
+          relPath: path.relative(folder.uri.fsPath, absPath),
+        });
+      }, token);
+    }
+    if (token.isCancellationRequested) return undefined;
+    if (targets.length === 0) return [];
+
+    // Use the in-memory text of any open document so unsaved changes are
+    // reflected in the scan, falling back to the on-disk version otherwise.
+    const openText = new Map<string, string>();
+    for (const d of vscode.workspace.textDocuments) {
+      if (d.uri.scheme === 'file') openText.set(d.uri.fsPath, d.getText());
+    }
+
+    progress.report({ message: `${targets.length} file${targets.length === 1 ? '' : 's'}` });
+
+    const out: WorkspaceHit[] = [];
+    let next = 0;
+    let done = 0;
+    const total = targets.length;
+    const concurrency = Math.min(8, total);
+
+    await Promise.all(Array.from({ length: concurrency }, async () => {
+      while (next < total) {
+        if (token.isCancellationRequested) return;
+        const t = targets[next++];
+        let text: string;
+        const open = openText.get(t.absPath);
+        if (open !== undefined) {
+          text = open;
+        } else {
+          try {
+            text = await fsp.readFile(t.absPath, 'utf8');
+          } catch {
+            done++;
+            continue;
+          }
+        }
+        const findings = scanText(text, RULES, t.lang);
+        for (const f of findings) {
+          const lc = offsetToLineCol(text, f.offset);
+          out.push({ uri: t.uri, relPath: t.relPath, finding: f, displayLine: lc.line, displayCol: lc.col });
+        }
+        done++;
+        if (done === total || done % 25 === 0) {
+          progress.report({ message: `${done}/${total} scanned, ${out.length} finding${out.length === 1 ? '' : 's'}` });
+        }
+      }
+    }));
+
+    if (token.isCancellationRequested) return undefined;
+    return out;
+  });
+
+  if (hits === undefined) return;
+  if (hits.length === 0) {
+    vscode.window.showInformationMessage('LLM Slop Detector: no findings in the workspace.');
+    return;
+  }
+
+  hits.sort((a, b) => {
+    const cmp = a.relPath.localeCompare(b.relPath);
+    if (cmp !== 0) return cmp;
+    return a.finding.offset - b.finding.offset;
+  });
+
+  const counts: Record<Severity, number> = { error: 0, warning: 0, information: 0, hint: 0 };
+  const fileSet = new Set<string>();
+  for (const h of hits) {
+    counts[h.finding.severity]++;
+    fileSet.add(h.relPath);
+  }
+  const summaryParts: string[] = [];
+  if (counts.error) summaryParts.push(`${counts.error} error${counts.error === 1 ? '' : 's'}`);
+  if (counts.warning) summaryParts.push(`${counts.warning} warning${counts.warning === 1 ? '' : 's'}`);
+  if (counts.information) summaryParts.push(`${counts.information} info`);
+  if (counts.hint) summaryParts.push(`${counts.hint} hint${counts.hint === 1 ? '' : 's'}`);
+  const summary = `${hits.length} finding${hits.length === 1 ? '' : 's'} in ${fileSet.size} file${fileSet.size === 1 ? '' : 's'} (${summaryParts.join(', ')})`;
+
+  type Item = vscode.QuickPickItem & { hit: WorkspaceHit };
+  const items: Item[] = hits.map(h => ({
+    label: `$(${severityCodicon(severityToVscode(h.finding.severity))}) ${h.finding.matchText.trim() || h.finding.code}`,
+    description: `${h.relPath}:${h.displayLine}:${h.displayCol}`,
+    detail: h.finding.message,
+    hit: h,
+  }));
+
+  const pick = await vscode.window.showQuickPick(items, {
+    title: summary,
+    matchOnDescription: true,
+    matchOnDetail: true,
+  });
+  if (!pick) return;
+
+  const doc = await vscode.workspace.openTextDocument(pick.hit.uri);
+  const editor = await vscode.window.showTextDocument(doc);
+  const start = doc.positionAt(pick.hit.finding.offset);
+  const end = doc.positionAt(pick.hit.finding.offset + pick.hit.finding.length);
+  const range = new vscode.Range(start, end);
+  editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+  editor.selection = new vscode.Selection(range.start, range.end);
 }
 
 // ---------------------------------------------------------------------------

--- a/test-fixtures/.slopignore
+++ b/test-fixtures/.slopignore
@@ -1,0 +1,1 @@
+ignored.md

--- a/test-fixtures/README.md
+++ b/test-fixtures/README.md
@@ -1,0 +1,5 @@
+Sample fixtures for the Extension Development Host.
+
+Press F5 to launch the host, which boots into this folder via `.vscode/launch.json`. Open any of the files here to exercise diagnostics, code actions, the status bar, and the workspace scan command.
+
+Files in this folder intentionally contain LLM slop. The repo's root `.slopignore` excludes the folder so the pre-commit hook does not flag the seed content.

--- a/test-fixtures/clean.md
+++ b/test-fixtures/clean.md
@@ -1,0 +1,3 @@
+# A clean file
+
+This file has no flagged content. Open it alongside the slop fixtures to confirm the status bar shows the green check and the Problems panel stays empty for this document.

--- a/test-fixtures/ignored.md
+++ b/test-fixtures/ignored.md
@@ -1,0 +1,3 @@
+# Ignored on purpose
+
+This file is excluded by `.slopignore` in this folder. Even though it contains slop like delve and leverage and a tapestry of cliches, neither the workspace scan nor the per-file diagnostics should report findings for it.

--- a/test-fixtures/markdown-slop.md
+++ b/test-fixtures/markdown-slop.md
@@ -1,0 +1,7 @@
+# Sample markdown with slop
+
+Let us delve into the rich tapestry of modern AI assistants. It’s worth noting that we should leverage every tool at our disposal — a testament to the multifaceted nature of the craft.
+
+In today’s fast-paced world, teams embark on a journey to harness the power of language models… navigating the complexities of prompt design with meticulous care.
+
+A short clean paragraph follows here so you can compare flagged lines against unflagged ones.

--- a/test-fixtures/nested/more-slop.md
+++ b/test-fixtures/nested/more-slop.md
@@ -1,0 +1,5 @@
+# Nested file
+
+This file lives one directory down so the workspace scan exercises recursion.
+
+It’s important to note that we must underscore the realm of multifaceted concerns at the heart of every modern stack.

--- a/test-fixtures/plain-slop.txt
+++ b/test-fixtures/plain-slop.txt
@@ -1,0 +1,6 @@
+Plaintext fixture with invisible Unicode.
+
+This sentence contains a non breaking space between "non" and "breaking".
+And this one has a zero​width space hidden inside "zerowidth".
+
+Nothing else on this line should trip the detector.


### PR DESCRIPTION
Closes #48.

## Summary

- Adds `LLM Slop Detector: Scan workspace` command. Walks workspace folders with the same prose + opt-in code-comment gating the live diagnostics use, respects `.slopignore` and `llmSlopDetector.exclude`, presents findings in a quick pick grouped by file. Selecting a finding opens the file and selects the range.
- Cancellable via `window.withProgress`. 8-way concurrent file reads. Uses the in-memory text of open documents so unsaved edits are reflected.
- Adds `test-fixtures/` (intentional slop) and points `.vscode/launch.json` at it so F5 boots the Extension Development Host directly into a folder. Root `.slopignore` and `.vscodeignore` exclude the fixtures from self-linting and from the published vsix.

Follow-up tracked in #52 for an Explorer context-menu entry point.

## Test plan

- [ ] `npm run compile` succeeds
- [ ] Press F5; EDH opens with `test-fixtures/` as the workspace
- [ ] Run `LLM Slop Detector: Scan workspace`: quick pick lists ~16 findings across `markdown-slop.md`, `plain-slop.txt`, `nested/more-slop.md`; `ignored.md` is absent (filtered by fixture-local `.slopignore`)
- [ ] Selecting a finding opens the file and selects the range
- [ ] Title line shows `N findings in M files (E errors, W warnings, I info, H hints)`
- [ ] On a larger repo (try opening this repo as the dev-host workspace), the progress notification stays responsive and Cancel aborts the scan
- [ ] Toggling `llmSlopDetector.scanCodeComments` widens the scan to source files