### PR TITLE
fix: run npm publish via npx instead of upgrading in place

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,8 +45,5 @@ jobs:
         run: npx --yes @vscode/vsce publish -p "$VSCE_PAT"
         if: ${{ steps.release.outputs.release_created }}
 
-      - run: npm install -g npm@latest
-        if: ${{ steps.release.outputs.release_created }}
-
-      - run: npm publish
+      - run: npx -y npm@latest publish
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Summary
The 0.6.1 release workflow failed on the \`npm install -g npm@latest\` step with \`MODULE_NOT_FOUND: 'promise-retry'\`. Runners ship npm 10 bundled into the node install, and upgrading in place corrupts its own \`node_modules\` mid-way -- a known npm self-upgrade bug.

Fix: run publish via \`npx -y npm@latest publish\` instead. That downloads a fresh npm into the npx cache and runs it in isolation, so the global npm stays untouched.

## Recovery
0.6.1 went to the Marketplace and Releases but missed npm again. Same pattern as before -- let this \`fix:\` cut 0.6.2 and the fixed workflow should publish it end-to-end.

## Test plan
- [ ] Merge this PR.
- [ ] Merge the release-please Release PR it triggers (0.6.2).
- [ ] \`npm view llm-slop-detector versions\` shows 0.6.2.
- [ ] \`npx llm-slop-detector@latest --version\` prints 0.6.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)