### PR TITLE
feat: read-only page scan mode for the browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ npm run build:browser
 
 Toggle off globally (or per-site) via the extension's toolbar button. Pick rule packs in the options page.
 
+### Read-only page scan
+
+The toolbar popup also has a **Scan this page** button that highlights slop in any webpage you're reading -- a blog post, a Reddit thread, a LinkedIn update -- not just textareas. Findings are shown with a subtle wavy underline under the flagged word and a floating panel listing them in reading order, with click-to-jump and a clear-highlights button. The scan is a one-shot snapshot; re-click to rescan after the page changes.
+
+Turn this off in the options page if you only want to lint your own writing. The scan is explicit (never auto-runs), local-only (no network), and one-shot per click (no background observers).
+
 ### Known limitations (v1)
 
 - `contenteditable` editors (Gmail compose, Substack, Notion, LinkedIn) are not yet supported -- only `<textarea>` and `<input type=text>`. Inline marks only render over textareas.

--- a/extension-browser/src/action.html
+++ b/extension-browser/src/action.html
@@ -19,6 +19,10 @@
       <span>Enabled on <strong id="host-label"></strong></span>
     </label>
   </section>
+  <section id="page-scan-section" hidden>
+    <button type="button" id="scan-page">Scan this page</button>
+    <p class="hint">Highlights slop in the current page's text (read-only mode).</p>
+  </section>
   <section class="note">
     <p id="status">Reload the page after changing settings.</p>
   </section>

--- a/extension-browser/src/action.ts
+++ b/extension-browser/src/action.ts
@@ -55,6 +55,34 @@ async function init() {
     else window.open(api.runtime.getURL('options.html'));
   });
 
+  // Page-scan button: only visible when read-only mode is enabled AND we're
+  // on a valid http(s) tab.
+  const pageScanSection = $('page-scan-section');
+  const scanBtn = $('scan-page') as HTMLButtonElement;
+  if (prefs.readOnlyEnabled && host) {
+    pageScanSection.hidden = false;
+    scanBtn.addEventListener('click', async () => {
+      try {
+        const tabs = await api.tabs.query({ active: true, currentWindow: true });
+        const tabId = tabs[0]?.id;
+        if (tabId == null) return;
+        await api.tabs.sendMessage(tabId, { type: 'lsd:runPageScan' });
+        window.close();
+      } catch (e) {
+        // Common cause: the tab was loaded before the extension was
+        // installed or reloaded, so the content script isn't injected
+        // in it yet. A tab reload fixes it.
+        const msg = String((e as Error)?.message ?? e);
+        if (/receiving end does not exist|could not establish/i.test(msg)) {
+          scanBtn.textContent = 'Reload tab first';
+        } else {
+          scanBtn.textContent = 'Scan failed';
+        }
+        window.setTimeout(() => { scanBtn.textContent = 'Scan this page'; }, 2000);
+      }
+    });
+  }
+
   function renderStatus() {
     if (!prefs.enabled) {
       statusEl.textContent = 'Off everywhere. Reload the page to take effect.';

--- a/extension-browser/src/content.ts
+++ b/extension-browser/src/content.ts
@@ -66,31 +66,39 @@ let activeEditorEl: (HTMLTextAreaElement | HTMLInputElement) | null = null;
 
 async function main() {
   prefs = await getPrefs();
-  if (!prefs.enabled || isHostDisabled(prefs, HOST)) return;
-
   rules = buildRules(prefs.enabledPacks);
   injectStyles();
-  scanDocument();
-  observeMutations();
+  // The page-scan message handler is always installed so the user can run a
+  // read-only scan even on hosts where editor scanning is disabled (or when
+  // editor scanning is off globally).
+  installMessageHandler();
+
+  const editorScanningOn = prefs.enabled && !isHostDisabled(prefs, HOST);
+  if (editorScanningOn) {
+    scanDocument();
+    observeMutations();
+  }
 
   onPrefsChanged(next => {
     const wasOn = prefs.enabled && !isHostDisabled(prefs, HOST);
     prefs = next;
     const isOn = prefs.enabled && !isHostDisabled(prefs, HOST);
-    if (!isOn) {
-      teardown();
+    rules = buildRules(prefs.enabledPacks);
+
+    if (!isOn && wasOn) {
+      teardownEditors();
       return;
     }
-    if (!wasOn) {
+    if (isOn && !wasOn) {
       // Re-init from scratch -- easier than tracking which editors we had.
-      rules = buildRules(prefs.enabledPacks);
       injectStyles();
       scanDocument();
       return;
     }
-    // Packs changed: rebuild rules and rescan every known editor.
-    rules = buildRules(prefs.enabledPacks);
-    rescanAll();
+    if (isOn) {
+      // Packs changed: rescan every known editor with the new rules.
+      rescanAll();
+    }
   });
 }
 
@@ -112,15 +120,15 @@ function buildRules(enabledPacks: string[]): RuleSet {
   });
 }
 
-function teardown() {
+function teardownEditors() {
   for (const ed of editorRegistry) {
     const s = editors.get(ed);
     s?.resizeObserver?.disconnect();
+    s?.badge.remove();
+    s?.mirror?.remove();
     editors.delete(ed);
   }
   editorRegistry.clear();
-  document.querySelectorAll(`.${HOST_CLASS}`).forEach(n => n.remove());
-  document.getElementById(STYLE_ID)?.remove();
   closePopover();
 }
 
@@ -261,25 +269,52 @@ function onDocMouseMove(e: MouseEvent) {
 }
 
 function processHover(x: number, y: number) {
-  const hit = findMarkAtPoint(x, y);
-  if (!hit) { hideTooltip(); return; }
-  const key = `${hit.mirrorKey}:${hit.offset}`;
-  const msg = hit.mark.getAttribute('data-lsd-message') || '';
-  showTooltip(msg, x, y, key);
+  const edHit = findMarkAtPoint(x, y);
+  if (edHit) {
+    const key = `ed:${edHit.mirrorKey}:${edHit.offset}`;
+    const msg = edHit.mark.getAttribute('data-lsd-message') || '';
+    showTooltip(msg, x, y, key);
+    return;
+  }
+  const rdHit = findRdMarkAtPoint(x, y);
+  if (rdHit) {
+    const key = `rd:${rdHit.index}`;
+    const msg = rdHit.element.getAttribute('data-lsd-message') || '';
+    showTooltip(msg, x, y, key);
+    return;
+  }
+  hideTooltip();
 }
 
 function onDocClick(e: MouseEvent) {
-  // Ignore clicks inside our own popover / badge so they don't retrigger
-  // the jump when the user interacts with the popover itself.
+  // Ignore clicks inside our own popover / panel / badge so they don't
+  // retrigger the jump when the user interacts with our own UI.
   const target = e.target as HTMLElement | null;
   if (target?.closest(`.${HOST_CLASS}`)) return;
-  const hit = findMarkAtPoint(e.clientX, e.clientY);
-  if (!hit) return;
-  // Native textarea click has already run (focus + caret placement). We
-  // don't preventDefault; we only pop open the popover on top.
-  const state = hit.state;
-  if (!popover || activeEditorEl !== state.editor) openPopover(state);
-  if (hit.offset >= 0) highlightPopoverFinding(hit.offset);
+
+  const edHit = findMarkAtPoint(e.clientX, e.clientY);
+  if (edHit) {
+    const state = edHit.state;
+    if (!popover || activeEditorEl !== state.editor) openPopover(state);
+    if (edHit.offset >= 0) highlightPopoverFinding(edHit.offset);
+    return;
+  }
+
+  const rdHit = findRdMarkAtPoint(e.clientX, e.clientY);
+  if (rdHit) {
+    jumpToRdFinding(rdHit);
+    return;
+  }
+}
+
+function findRdMarkAtPoint(x: number, y: number): RdFinding | null {
+  for (const rf of rdFindings) {
+    const rects = rf.element.getClientRects();
+    for (const r of rects) {
+      if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) return rf;
+    }
+  }
+  return null;
 }
 
 type MarkHit = { mark: HTMLElement; state: EditorState; mirrorKey: string; offset: number };
@@ -980,8 +1015,362 @@ function injectStyles() {
       display: inline-block !important;
     }
     .${POPOVER_CLASS} .lsd-fix:hover { background: rgba(127,127,127,0.3) !important; }
+
+    /* ---- Read-only page scan ---- */
+    ${RD_MARK_TAG} {
+      border-radius: 2px !important;
+      /* Subtle styling: a thin underline so reading flow isn't disrupted as
+         badly as a background wash. Colour by severity. */
+      text-decoration: underline wavy !important;
+      text-underline-offset: 2px !important;
+      text-decoration-thickness: 1.5px !important;
+      cursor: help !important;
+    }
+    ${RD_MARK_TAG}.lsd-sev-error       { text-decoration-color: #d73a49 !important; }
+    ${RD_MARK_TAG}.lsd-sev-warning     { text-decoration-color: #b08800 !important; }
+    ${RD_MARK_TAG}.lsd-sev-information { text-decoration-color: #0366d6 !important; }
+    ${RD_MARK_TAG}.lsd-sev-hint        { text-decoration-color: #6a737d !important; }
+    @keyframes lsd-rd-pulse {
+      0%   { background: rgba(3, 102, 214, 0.5); }
+      100% { background: transparent; }
+    }
+    ${RD_MARK_TAG}.lsd-pulse {
+      animation: lsd-rd-pulse 1400ms ease-out 1 !important;
+      border-radius: 3px !important;
+    }
+
+    .${RD_PANEL_CLASS} {
+      position: fixed !important;
+      right: 16px !important;
+      bottom: 16px !important;
+      width: 340px !important;
+      max-height: 70vh !important;
+      display: flex !important;
+      flex-direction: column !important;
+      z-index: 2147483641 !important;
+      background: #ffffff !important;
+      color: #1c1c1c !important;
+      border: 1px solid #d9d9d4 !important;
+      border-radius: 6px !important;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.18) !important;
+      font-size: 13px !important;
+      line-height: 1.4 !important;
+    }
+    @media (prefers-color-scheme: dark) {
+      .${RD_PANEL_CLASS} {
+        background: #1c1f24 !important;
+        color: #e6e6e6 !important;
+        border-color: #2a2d33 !important;
+      }
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-head {
+      display: flex !important;
+      justify-content: space-between !important;
+      align-items: center !important;
+      padding: 6px 10px !important;
+      border-bottom: 1px solid #e5e5e0 !important;
+    }
+    @media (prefers-color-scheme: dark) {
+      .${RD_PANEL_CLASS} .lsd-rd-head { border-bottom-color: #2a2d33 !important; }
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-title { font-weight: 600 !important; font-size: 12px !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-close {
+      all: unset !important;
+      cursor: pointer !important;
+      padding: 2px 6px !important;
+      border-radius: 3px !important;
+      opacity: 0.7 !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-close:hover { opacity: 1 !important; background: rgba(127,127,127,0.15) !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-summary {
+      padding: 6px 10px !important;
+      border-bottom: 1px solid #e5e5e0 !important;
+      font-size: 12px !important;
+    }
+    @media (prefers-color-scheme: dark) {
+      .${RD_PANEL_CLASS} .lsd-rd-summary { border-bottom-color: #2a2d33 !important; }
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-counts { font-size: 14px !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-sevbits { margin-top: 4px !important; display: flex !important; gap: 6px !important; flex-wrap: wrap !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-sev {
+      font-size: 11px !important;
+      padding: 1px 6px !important;
+      border-radius: 3px !important;
+      color: #fff !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-sev.lsd-sev-error       { background: #d73a49 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-sev.lsd-sev-warning     { background: #b08800 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-sev.lsd-sev-information { background: #0366d6 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-sev.lsd-sev-hint        { background: #6a737d !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-cap {
+      margin-top: 6px !important;
+      padding: 4px 6px !important;
+      background: rgba(176, 136, 0, 0.15) !important;
+      border-radius: 3px !important;
+      font-size: 11px !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-empty {
+      color: #666 !important;
+      padding: 4px 0 !important;
+      font-style: italic !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-list {
+      overflow-y: auto !important;
+      padding: 6px 10px !important;
+      flex: 1 !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-item {
+      padding: 6px 8px !important;
+      margin-bottom: 6px !important;
+      border-left: 3px solid #d9d9d4 !important;
+      border-radius: 3px !important;
+      background: rgba(127,127,127,0.05) !important;
+      cursor: pointer !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-item:hover { background: rgba(127,127,127,0.12) !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-item.lsd-sev-error       { border-left-color: #d73a49 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-item.lsd-sev-warning     { border-left-color: #b08800 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-item.lsd-sev-information { border-left-color: #0366d6 !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-item.lsd-sev-hint        { border-left-color: #6a737d !important; }
+    .${RD_PANEL_CLASS} .lsd-rd-item-head {
+      display: flex !important; gap: 6px !important; align-items: center !important;
+      flex-wrap: wrap !important; margin-bottom: 4px !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-actions {
+      padding: 6px 10px !important;
+      border-top: 1px solid #e5e5e0 !important;
+    }
+    @media (prefers-color-scheme: dark) {
+      .${RD_PANEL_CLASS} .lsd-rd-actions { border-top-color: #2a2d33 !important; }
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-clear {
+      all: unset !important;
+      font: inherit !important;
+      font-size: 12px !important;
+      padding: 3px 8px !important;
+      background: rgba(215, 58, 73, 0.15) !important;
+      color: #d73a49 !important;
+      border-radius: 3px !important;
+      cursor: pointer !important;
+      font-weight: 600 !important;
+    }
+    .${RD_PANEL_CLASS} .lsd-rd-clear:hover { background: rgba(215, 58, 73, 0.25) !important; }
   `;
   document.documentElement.appendChild(style);
+}
+
+// ---------------------------------------------------------------------------
+// Read-only page scan (#69)
+// ---------------------------------------------------------------------------
+
+const RD_MARK_TAG = 'lsd-rd-mark';
+const RD_PANEL_CLASS = 'lsd-rd-panel';
+const RD_TOTAL_CAP = 500 * 1024;
+const RD_MIN_NODE_CHARS = 12;
+
+// Elements whose text we never scan in read-only mode. Script/style is a
+// parse-safety thing; pre/code/kbd/samp/tt/var are technical and would false-
+// positive on terminology; textarea/input are covered by the editor path;
+// template/iframe/svg/math/canvas either hide text or aren't useful.
+const RD_SKIP_TAGS = new Set([
+  'script', 'style', 'noscript', 'template', 'iframe',
+  'textarea', 'input', 'code', 'pre', 'samp', 'kbd', 'tt', 'var',
+  'svg', 'math', 'video', 'audio', 'object', 'embed', 'canvas',
+]);
+
+type RdFinding = { finding: Finding; element: HTMLElement; index: number };
+let rdFindings: RdFinding[] = [];
+let rdPanel: HTMLElement | null = null;
+
+function installMessageHandler() {
+  const api = (globalThis as any).browser ?? (globalThis as any).chrome;
+  api.runtime.onMessage.addListener((msg: any, _sender: any, sendResponse: (r: unknown) => void) => {
+    if (msg?.type === 'lsd:runPageScan') {
+      runPageScan();
+      sendResponse({ ok: true });
+    } else if (msg?.type === 'lsd:clearPageScan') {
+      clearPageScan();
+      sendResponse({ ok: true });
+    }
+    // Return value matters for cross-browser compatibility:
+    // - Chrome MV3: return true keeps the response channel open for async
+    //   sendResponse; falsy closes it. We call sendResponse synchronously
+    //   above, so false is correct.
+    // - Firefox: same semantics for the falsy case.
+    return false;
+  });
+}
+
+function runPageScan() {
+  if (!prefs.readOnlyEnabled) return;
+  clearPageScan();
+
+  const texts = collectReadOnlyTextNodes(document.body);
+  let totalScanned = 0;
+  let capHit = false;
+
+  for (const node of texts) {
+    if (!node.parentNode) continue; // removed between collection and wrap
+    const text = node.nodeValue ?? '';
+    if (text.length === 0) continue;
+    if (totalScanned + text.length > RD_TOTAL_CAP) { capHit = true; break; }
+    totalScanned += text.length;
+
+    const findings = scanText(text, rules, 'plaintext');
+    if (findings.length === 0) continue;
+
+    // Right-to-left so earlier offsets remain valid as we split the text
+    // node from the right. Skip findings that overlap with a later-wrapped
+    // range (shouldn't happen with current rules but is cheap insurance).
+    const sorted = [...findings].sort((a, b) => b.offset - a.offset);
+    let lastStart = Infinity;
+    for (const f of sorted) {
+      if (f.offset + f.length > lastStart) continue;
+      const mark = wrapTextNodeRange(node, f.offset, f.length, f.severity, f.message);
+      if (!mark) continue;
+      lastStart = f.offset;
+      rdFindings.push({ finding: f, element: mark, index: rdFindings.length });
+    }
+  }
+
+  // Sort results by document order so "jump next" feels like reading.
+  rdFindings.sort((a, b) => compareNodePositions(a.element, b.element));
+  rdFindings.forEach((rf, i) => { rf.index = i; rf.element.setAttribute('data-lsd-rd-index', String(i)); });
+
+  renderResultsPanel(capHit, totalScanned);
+}
+
+function collectReadOnlyTextNodes(root: Node): Text[] {
+  const out: Text[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as Element;
+        const tag = el.tagName.toLowerCase();
+        if (RD_SKIP_TAGS.has(tag)) return NodeFilter.FILTER_REJECT;
+        // Our own injected DOM, or a user editor we've attached to.
+        if (el.classList.contains(HOST_CLASS)) return NodeFilter.FILTER_REJECT;
+        const ce = el.getAttribute('contenteditable');
+        if (ce === '' || ce === 'true' || ce === 'plaintext-only') return NodeFilter.FILTER_REJECT;
+        // Hidden subtrees.
+        const cs = getComputedStyle(el);
+        if (cs.display === 'none' || cs.visibility === 'hidden') return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_SKIP;
+      }
+      const t = node as Text;
+      const v = t.nodeValue ?? '';
+      if (v.trim().length < RD_MIN_NODE_CHARS) return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  let n: Node | null;
+  while ((n = walker.nextNode())) {
+    if (n.nodeType === Node.TEXT_NODE) out.push(n as Text);
+  }
+  return out;
+}
+
+function wrapTextNodeRange(node: Text, offset: number, length: number, severity: Severity, message: string): HTMLElement | null {
+  try {
+    const range = document.createRange();
+    range.setStart(node, offset);
+    range.setEnd(node, offset + length);
+    const wrapper = document.createElement(RD_MARK_TAG);
+    wrapper.className = `lsd-rd-mark lsd-sev-${severity}`;
+    wrapper.setAttribute('data-lsd-message', message);
+    range.surroundContents(wrapper);
+    return wrapper;
+  } catch {
+    return null;
+  }
+}
+
+function compareNodePositions(a: Node, b: Node): number {
+  if (a === b) return 0;
+  const pos = a.compareDocumentPosition(b);
+  if (pos & Node.DOCUMENT_POSITION_FOLLOWING) return -1;
+  if (pos & Node.DOCUMENT_POSITION_PRECEDING) return 1;
+  return 0;
+}
+
+function clearPageScan() {
+  for (const rf of rdFindings) {
+    const el = rf.element;
+    const parent = el.parentNode;
+    if (!parent) continue;
+    // Unwrap: move children out, remove the wrapper.
+    while (el.firstChild) parent.insertBefore(el.firstChild, el);
+    parent.removeChild(el);
+    parent.normalize?.();
+  }
+  rdFindings = [];
+  rdPanel?.remove();
+  rdPanel = null;
+}
+
+function renderResultsPanel(capHit: boolean, bytesScanned: number) {
+  const panel = document.createElement('div');
+  panel.className = `${HOST_CLASS} ${RD_PANEL_CLASS}`;
+  panel.innerHTML = `
+    <div class="lsd-rd-head">
+      <span class="lsd-rd-title">Page scan</span>
+      <button class="lsd-rd-close" type="button" aria-label="Close">x</button>
+    </div>
+    <div class="lsd-rd-summary"></div>
+    <div class="lsd-rd-list"></div>
+    <div class="lsd-rd-actions">
+      <button class="lsd-rd-clear" type="button">Clear highlights</button>
+    </div>
+  `;
+  document.body.appendChild(panel);
+  rdPanel = panel;
+
+  const counts: Record<Severity, number> = { error: 0, warning: 0, information: 0, hint: 0 };
+  for (const rf of rdFindings) counts[rf.finding.severity]++;
+
+  const summary = panel.querySelector('.lsd-rd-summary') as HTMLElement;
+  const total = rdFindings.length;
+  const sevBits = (['error', 'warning', 'information', 'hint'] as Severity[])
+    .filter(s => counts[s] > 0)
+    .map(s => `<span class="lsd-rd-sev lsd-sev-${s}">${counts[s]} ${s}</span>`)
+    .join(' ');
+  const capBit = capHit
+    ? `<div class="lsd-rd-cap">Page exceeded ${RD_TOTAL_CAP / 1024} KB -- scanned first ${Math.round(bytesScanned / 1024)} KB.</div>`
+    : '';
+  summary.innerHTML = total === 0
+    ? '<div class="lsd-rd-empty">No slop detected on this page.</div>'
+    : `<div class="lsd-rd-counts"><strong>${total}</strong> finding${total === 1 ? '' : 's'}</div><div class="lsd-rd-sevbits">${sevBits}</div>${capBit}`;
+
+  const list = panel.querySelector('.lsd-rd-list') as HTMLElement;
+  for (const rf of rdFindings) {
+    const row = document.createElement('div');
+    row.className = `lsd-rd-item lsd-sev-${rf.finding.severity}`;
+    row.innerHTML = `
+      <div class="lsd-rd-item-head">
+        <span class="lsd-badge-sev lsd-sev-${escapeAttr(rf.finding.severity)}">${escapeText(rf.finding.severity)}</span>
+        <code class="lsd-match">${escapeText(rf.finding.matchText || '(empty)')}</code>
+      </div>
+      <div class="lsd-msg">${escapeText(rf.finding.message)}</div>
+    `;
+    row.addEventListener('click', () => jumpToRdFinding(rf));
+    list.appendChild(row);
+  }
+
+  (panel.querySelector('.lsd-rd-close') as HTMLElement).addEventListener('click', () => {
+    panel.remove();
+    rdPanel = null;
+  });
+  (panel.querySelector('.lsd-rd-clear') as HTMLElement).addEventListener('click', () => {
+    clearPageScan();
+  });
+}
+
+function jumpToRdFinding(rf: RdFinding) {
+  rf.element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  rf.element.classList.remove('lsd-pulse');
+  void rf.element.offsetWidth;
+  rf.element.classList.add('lsd-pulse');
+  window.setTimeout(() => rf.element.classList.remove('lsd-pulse'), 1500);
 }
 
 function escapeText(s: string): string {

--- a/extension-browser/src/options.css
+++ b/extension-browser/src/options.css
@@ -45,6 +45,14 @@ h2 { margin: 0 0 0.5rem; font-size: 1.05rem; }
   color: var(--muted);
   font-size: 0.9rem;
 }
+.toggle {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+.toggle input { margin: 0; }
 .packs {
   display: flex;
   flex-wrap: wrap;

--- a/extension-browser/src/options.html
+++ b/extension-browser/src/options.html
@@ -11,6 +11,15 @@
     <p class="tagline">Flags invisible Unicode, AI-style punctuation, and telltale LLM phrases in any textarea on the web.</p>
 
     <section>
+      <h2>Read-only page scanning</h2>
+      <p class="hint">When on, the toolbar icon shows a "Scan this page" button that highlights slop in any webpage you're reading (not just textareas). Off by default if you only want to lint your own writing.</p>
+      <label class="toggle">
+        <input type="checkbox" id="readonly-enabled">
+        <span>Enable read-only page scanning</span>
+      </label>
+    </section>
+
+    <section>
       <h2>Rule packs</h2>
       <p class="hint">Core rules are always on. Packs add extra model-specific or domain-specific phrases.</p>
       <div id="packs" class="packs"></div>

--- a/extension-browser/src/options.ts
+++ b/extension-browser/src/options.ts
@@ -54,12 +54,18 @@ async function init() {
   let prefs = await getPrefs();
   const packsEl = $('packs');
   const hostsEl = $('disabled-hosts');
+  const roToggle = $('readonly-enabled') as HTMLInputElement;
   renderPacks(packsEl, prefs);
   renderDisabledHosts(hostsEl, prefs);
+  roToggle.checked = prefs.readOnlyEnabled;
+  roToggle.addEventListener('change', async () => {
+    await updatePrefs({ readOnlyEnabled: roToggle.checked });
+  });
   onPrefsChanged(next => {
     prefs = next;
     renderPacks(packsEl, prefs);
     renderDisabledHosts(hostsEl, prefs);
+    roToggle.checked = prefs.readOnlyEnabled;
   });
 }
 

--- a/extension-browser/src/popup.css
+++ b/extension-browser/src/popup.css
@@ -47,6 +47,20 @@ label.toggle {
 }
 label.toggle input { margin: 0; }
 label.toggle strong { font-weight: 600; }
+section button#scan-page {
+  width: 100%;
+  font: inherit;
+  padding: 6px 10px;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+section button#scan-page:hover { filter: brightness(0.95); }
+section button#scan-page:disabled { opacity: 0.5; cursor: not-allowed; }
+section .hint { font-size: 12px; color: var(--muted); margin: 6px 0 0; }
 footer {
   display: flex;
   justify-content: space-between;

--- a/extension-browser/src/storage.ts
+++ b/extension-browser/src/storage.ts
@@ -10,12 +10,14 @@ export type Prefs = {
   enabled: boolean;
   enabledPacks: string[];
   disabledHosts: string[];
+  readOnlyEnabled: boolean;
 };
 
 export const DEFAULTS: Prefs = {
   enabled: true,
   enabledPacks: [],
   disabledHosts: [],
+  readOnlyEnabled: true,
 };
 
 const KEY = 'prefs';
@@ -31,6 +33,7 @@ export async function getPrefs(): Promise<Prefs> {
     disabledHosts: Array.isArray(stored?.disabledHosts)
       ? (stored!.disabledHosts as unknown[]).filter((x): x is string => typeof x === 'string')
       : DEFAULTS.disabledHosts,
+    readOnlyEnabled: typeof stored?.readOnlyEnabled === 'boolean' ? stored.readOnlyEnabled : DEFAULTS.readOnlyEnabled,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a \"Scan this page\" button in the toolbar popup that highlights slop in any webpage's rendered text -- not just editors. One-shot, click-to-scan. No auto-scan, no background observers, no network calls, no telemetry.

Closes #69.

## What landed

- **Pref + options toggle**: new \`readOnlyEnabled\` in prefs (default on). Options page gets an \"Enable read-only page scanning\" section. When off, the popup button is hidden.
- **Popup button**: visible when \`readOnlyEnabled && activeTabIsHttp\`. Clicking sends \`lsd:runPageScan\` to the active tab and closes the popup.
- **Content script (message handler)**: installed unconditionally at content-script startup, so page scan works even on hosts where editor scanning is per-site disabled. Receives \`lsd:runPageScan\` and \`lsd:clearPageScan\`.
- **DOM walker**: \`TreeWalker\` over the body that rejects \`script\`/\`style\`/\`noscript\`/\`template\`/\`iframe\`, \`textarea\`/\`input\` (covered by the editor path), \`pre\`/\`code\`/\`kbd\`/\`samp\`/\`tt\`/\`var\` (technical false positives), \`svg\`/\`math\`/\`video\`/\`audio\`/\`canvas\`, \`[contenteditable]\`, hidden subtrees (\`display: none\` / \`visibility: hidden\`), and our own injected DOM (\`.lsd-host\`).
- **Scan + wrap**: per text node, \`scanText\` with language=\`plaintext\`. Findings wrapped via \`Range.surroundContents\` with a \`<lsd-rd-mark>\` custom element (hyphenated tag so host-page selectors like \`.parent > span\` aren't affected). Right-to-left wrap order keeps earlier offsets valid.
- **500 KB soft cap** on total extracted text. If exceeded, scan stops and the panel surfaces \"scanned first N KB\".
- **Results panel** (fixed bottom-right): findings sorted by document order so clicking down the list feels like reading top-down. Each row has severity badge, match text, rule message, and click-to-jump that scrolls the match into view with a blue pulse.
- **Subtle styling**: wavy underline on marks (not a background wash) so reading flow isn't wrecked.
- **Unified hit-testing**: hover tooltip and click-to-jump integrate with the existing editor-mark paths. \`processHover\` and \`onDocClick\` first check editor (mirror) marks, then page marks. Same tooltip UI.
- **Clear Highlights** button unwraps all marks and dismisses the panel.

## Chrome MV3 messaging gotcha

During testing the popup was showing \"Scan failed\". Root cause: the content script's \`runtime.onMessage\` listener returned \`Promise.resolve(...)\`, which Chrome MV3 interprets as \"no async response expected\" and closes the port before our \"response\" arrives. The popup's \`await tabs.sendMessage(...)\` rejects. Fix: call \`sendResponse\` synchronously + \`return false\`. Popup also now shows a more useful \"Reload tab first\" error when the content script isn't injected (common when the extension was reloaded but the tab wasn't).

## Non-goals (deferred)

- **Auto-scan on page load**: explicitly out of scope. Too noisy, too expensive, bad permission story.
- **Per-domain auto-scan whitelist**: requires \`chrome.permissions.request\` flows. Follow-up if there's demand.
- **\"Fix this\" on page marks**: the reader doesn't own the content; read-only stays read-only.
- **Score / percentage classifier**: rule engine detects style markers, not authorship. Won't pretend to.
- **Closed shadow roots** (YouTube comments, some component libraries): invisible to us, documented limitation.
- **Canvas-rendered text** (Google Docs): permanently out.
- **PDF viewer**: out.

## Test plan

- [x] \`npx tsc -p extension-browser/tsconfig.json\` clean.
- [x] \`npm run build:browser\` produces a valid unpacked extension (~114 KB content.js, 132 KB total).
- [x] Dog-fooded in Arc on a local test page with a mix of slop prose, technical code blocks, and a blockquote. Confirmed:
  - Marks appear on slop prose (delve, tapestry, cutting-edge, etc.).
  - \`<pre>\`/\`<code>\` blocks are never marked.
  - Floating panel lists findings by reading order.
  - Click a row -> page scrolls to the match and pulses blue.
  - Clear button removes all marks + panel cleanly.
  - Hover over a page mark shows the tooltip (reusing the editor-mark tooltip code).
  - Options toggle off -> popup button disappears after reopening the popup.
- [ ] **Reviewer: retest in Firefox.**

## Files

- Added: (none)
- Modified: \`extension-browser/src/content.ts\` (+370), \`extension-browser/src/action.html\`, \`extension-browser/src/action.ts\`, \`extension-browser/src/options.html\`, \`extension-browser/src/options.ts\`, \`extension-browser/src/options.css\`, \`extension-browser/src/popup.css\`, \`extension-browser/src/storage.ts\`, \`README.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)