### PR TITLE
feat: contenteditable support in the browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ No install needed -- paste text into the [web playground](https://mandakan.githu
 
 ## Browser extension (Chrome, Arc, Firefox)
 
-A WebExtension that scans `<textarea>` and text inputs as you type on any webpage, highlights findings inline with colour-coded marks over the text, and shows a small "N slop" badge next to each editor. Click the badge for a per-finding popover with severity, reason, source pack, a per-finding "Fix this" button, and a "Fix all chars" button that applies every deterministic character replacement (em dash, curly quotes, zero-width, etc.) at once. Runs entirely in the browser -- no network calls, no telemetry.
+A WebExtension that scans `<textarea>`, text inputs, and `contenteditable` elements (Gmail compose, vanilla rich-text widgets) as you type on any webpage. Findings are highlighted inline with colour-coded marks -- textarea marks are tinted background, contenteditable marks are wavy underlines so they don't disturb reading of styled content. A small "N slop" badge next to each editor opens a per-finding popover with severity, reason, source pack, per-finding "Fix this" buttons, and a "Fix all chars" button that applies every deterministic character replacement (em dash, curly quotes, zero-width, etc.) at once. For contenteditables the fix goes through `execCommand('insertText')` so the host editor's undo stack still works (`Cmd+Z`). Runs entirely in the browser -- no network calls, no telemetry.
 
 **Install from source (until stores are wired up):**
 
@@ -36,9 +36,10 @@ Turn this off in the options page if you only want to lint your own writing. The
 
 ### Known limitations (v1)
 
-- `contenteditable` editors (Gmail compose, Substack, Notion, LinkedIn) are not yet supported -- only `<textarea>` and `<input type=text>`. Inline marks only render over textareas.
+- Rich editors with virtual-DOM reconcilers (Notion/Lexical, Substack/ProseMirror, LinkedIn/Draft.js, Twitter/X) strip our inline marks on their next render cycle. The badge count and popover still work, but inline underlines won't persist. Plain `contenteditable` (Gmail compose, vanilla rich-text widgets) is supported.
 - Google Docs uses a canvas-based renderer with no real DOM text; the extension can't see its contents and won't work there.
 - Cross-origin iframes are invisible for the same-origin-policy reason.
+- Inline phrase matches that straddle inline formatting (e.g. a word that's partially italicised) appear in the popover list but without an inline mark, because `Range.surroundContents` rejects ranges that cross element boundaries. Workaround: strip the formatting if you want the mark.
 
 ## Features
 

--- a/extension-browser/manifest.json
+++ b/extension-browser/manifest.json
@@ -24,7 +24,8 @@
       "matches": ["http://*/*", "https://*/*"],
       "js": ["content.js"],
       "run_at": "document_idle",
-      "all_frames": true
+      "all_frames": true,
+      "match_about_blank": true
     }
   ],
   "browser_specific_settings": {

--- a/extension-browser/manifest.json
+++ b/extension-browser/manifest.json
@@ -24,7 +24,7 @@
       "matches": ["http://*/*", "https://*/*"],
       "js": ["content.js"],
       "run_at": "document_idle",
-      "all_frames": false
+      "all_frames": true
     }
   ],
   "browser_specific_settings": {

--- a/extension-browser/src/content.ts
+++ b/extension-browser/src/content.ts
@@ -140,7 +140,11 @@ function teardownEditors() {
 // Editor discovery
 // ---------------------------------------------------------------------------
 
-const TEXT_CONTROL_SELECTOR = 'textarea, input[type=text]';
+// `input:not([type])` covers Gmail's subject row and other hosts that
+// leave the attribute off (HTML default type is text). We still exclude
+// typed inputs like email/url/password/search where slop scanning would
+// either clash with validation or just produce noise.
+const TEXT_CONTROL_SELECTOR = 'textarea, input[type=text], input:not([type])';
 // [role="textbox"] with aria-multiline catches rich editors like Gmail's
 // compose body that set the contenteditable attribute dynamically (or via
 // designMode on a nested document).

--- a/extension-browser/src/content.ts
+++ b/extension-browser/src/content.ts
@@ -141,7 +141,10 @@ function teardownEditors() {
 // ---------------------------------------------------------------------------
 
 const TEXT_CONTROL_SELECTOR = 'textarea, input[type=text]';
-const CE_SELECTOR = '[contenteditable="true"], [contenteditable=""]';
+// [role="textbox"] with aria-multiline catches rich editors like Gmail's
+// compose body that set the contenteditable attribute dynamically (or via
+// designMode on a nested document).
+const CE_SELECTOR = '[contenteditable="true"], [contenteditable=""], [role="textbox"][aria-multiline="true"]';
 const ALL_EDITOR_SELECTOR = `${TEXT_CONTROL_SELECTOR}, ${CE_SELECTOR}`;
 
 function attachAny(el: HTMLElement) {
@@ -159,17 +162,36 @@ function scanDocument() {
 function observeMutations() {
   const mo = new MutationObserver(mutations => {
     for (const m of mutations) {
+      if (m.type === 'attributes') {
+        if (m.attributeName === 'contenteditable' && m.target instanceof HTMLElement) {
+          const el = m.target;
+          if (el.matches(CE_SELECTOR)) attachContenteditable(el);
+        }
+        continue;
+      }
       m.addedNodes.forEach(node => {
         if (!(node instanceof HTMLElement)) return;
         if (node.matches(ALL_EDITOR_SELECTOR)) attachAny(node);
         node.querySelectorAll?.(ALL_EDITOR_SELECTOR).forEach(el => attachAny(el as HTMLElement));
       });
-      // An element may become contenteditable dynamically; the attribute
-      // mutation case is rare and adds observer cost, so we skip it and
-      // rely on initial sweep + childList additions only.
     }
   });
-  mo.observe(document.documentElement, { childList: true, subtree: true });
+  mo.observe(document.documentElement, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['contenteditable'],
+  });
+
+  // Safety net for host pages that wire up editors behind our back (e.g.
+  // Gmail compose, some React portals). When an unattached editor gains
+  // focus, attach it then.
+  document.addEventListener('focusin', e => {
+    const t = e.target as HTMLElement | null;
+    if (!t || editors.has(t)) return;
+    if (t.matches(TEXT_CONTROL_SELECTOR)) attach(t);
+    else if (t.matches(CE_SELECTOR)) attachContenteditable(t);
+  }, { capture: true });
 }
 
 function attach(el: HTMLElement) {
@@ -278,10 +300,12 @@ function attachContenteditable(el: HTMLElement) {
   for (const ed of editorRegistry) {
     if (ed !== el && ed.contains(el)) return;
   }
-  // Minimum visible size guard so we don't attach to empty 0-height divs that
-  // become contenteditable only when clicked.
-  const rect = el.getBoundingClientRect();
-  if (rect.width < 120 || rect.height < 16) return;
+  // Reject truly invisible editors (display: none, visibility: hidden). We
+  // no longer reject by bounding rect -- Gmail's compose body has zero size
+  // before the dialog opens, and the MO / focusin paths re-attach on the
+  // way in.
+  const cs = getComputedStyle(el);
+  if (cs.display === 'none' || cs.visibility === 'hidden') return;
 
   const badge = document.createElement('span');
   badge.className = `${HOST_CLASS} ${BADGE_CLASS} lsd-hidden`;
@@ -1780,6 +1804,10 @@ function escapeText(s: string): string {
 function escapeAttr(s: string): string {
   return escapeText(s);
 }
+
+// Marker so you can verify the content script is running in any given frame
+// by checking `window.__lsd` in the DevTools console.
+(window as any).__lsd = { loaded: true, build: '2' };
 
 // Kick things off. document_idle in the manifest means the DOM is parsed;
 // still check in case a host page defers content.

--- a/extension-browser/src/content.ts
+++ b/extension-browser/src/content.ts
@@ -39,12 +39,16 @@ const MIN_EDITOR_CHARS = 40; // skip search boxes
 // code) rather than adding them.
 const LANGUAGE: Language = 'markdown';
 
-type EditorKind = 'textarea' | 'input';
+type EditorKind = 'textarea' | 'input' | 'contenteditable';
+type TextControl = HTMLTextAreaElement | HTMLInputElement;
+type EditorEl = TextControl | HTMLElement;
 type EditorState = {
-  editor: HTMLTextAreaElement | HTMLInputElement;
+  editor: EditorEl;
   kind: EditorKind;
   badge: HTMLElement;
-  mirror: HTMLElement | null;
+  mirror: HTMLElement | null;         // textarea only
+  marks: HTMLElement[];                // contenteditable only: live <lsd-ce-mark> wrappers
+  applyingMarks: boolean;              // contenteditable only: suppress input feedback during rewrap
   debounceHandle: number | null;
   lastFindings: Finding[];
   lastText: string;
@@ -54,11 +58,11 @@ type EditorState = {
 const editors = new WeakMap<Element, EditorState>();
 // Separate iterable registry so reflowAll() can walk every live editor.
 // We prune entries when their editor leaves the DOM inside positionOverlays.
-const editorRegistry = new Set<HTMLTextAreaElement | HTMLInputElement>();
+const editorRegistry = new Set<EditorEl>();
 let rules: RuleSet;
 let prefs: Prefs;
 let popover: HTMLElement | null = null;
-let activeEditorEl: (HTMLTextAreaElement | HTMLInputElement) | null = null;
+let activeEditorEl: EditorEl | null = null;
 
 // ---------------------------------------------------------------------------
 // Bootstrap
@@ -136,8 +140,20 @@ function teardownEditors() {
 // Editor discovery
 // ---------------------------------------------------------------------------
 
+const TEXT_CONTROL_SELECTOR = 'textarea, input[type=text]';
+const CE_SELECTOR = '[contenteditable="true"], [contenteditable=""]';
+const ALL_EDITOR_SELECTOR = `${TEXT_CONTROL_SELECTOR}, ${CE_SELECTOR}`;
+
+function attachAny(el: HTMLElement) {
+  if (el.matches(TEXT_CONTROL_SELECTOR)) {
+    attach(el);
+  } else if (el.matches(CE_SELECTOR)) {
+    attachContenteditable(el);
+  }
+}
+
 function scanDocument() {
-  document.querySelectorAll('textarea, input[type=text]').forEach(el => attach(el as HTMLElement));
+  document.querySelectorAll(ALL_EDITOR_SELECTOR).forEach(el => attachAny(el as HTMLElement));
 }
 
 function observeMutations() {
@@ -145,9 +161,12 @@ function observeMutations() {
     for (const m of mutations) {
       m.addedNodes.forEach(node => {
         if (!(node instanceof HTMLElement)) return;
-        if (node.matches('textarea, input[type=text]')) attach(node);
-        node.querySelectorAll?.('textarea, input[type=text]').forEach(el => attach(el as HTMLElement));
+        if (node.matches(ALL_EDITOR_SELECTOR)) attachAny(node);
+        node.querySelectorAll?.(ALL_EDITOR_SELECTOR).forEach(el => attachAny(el as HTMLElement));
       });
+      // An element may become contenteditable dynamically; the attribute
+      // mutation case is rare and adds observer cost, so we skip it and
+      // rely on initial sweep + childList additions only.
     }
   });
   mo.observe(document.documentElement, { childList: true, subtree: true });
@@ -190,6 +209,8 @@ function attach(el: HTMLElement) {
     kind: isTextarea ? 'textarea' : 'input',
     badge,
     mirror: null,
+    marks: [],
+    applyingMarks: false,
     debounceHandle: null,
     lastFindings: [],
     lastText: '',
@@ -229,6 +250,282 @@ function attach(el: HTMLElement) {
   installGlobalListeners();
   positionOverlays(state);
   runScan(state);
+}
+
+// ---------------------------------------------------------------------------
+// Contenteditable path (#71)
+// ---------------------------------------------------------------------------
+
+const CE_MARK_TAG = 'lsd-ce-mark';
+
+// Tags to skip while extracting plain text / fragments from a contenteditable.
+// Broader than the read-only list because we're inside a user-controlled
+// editor where script/style/etc. still shouldn't leak.
+const CE_EXTRACT_SKIP = new Set([
+  'script', 'style', 'noscript', 'template',
+  'svg', 'math', 'video', 'audio', 'object', 'embed', 'canvas',
+  'textarea', 'input',
+]);
+
+type CeFragment = { node: Text; textOffset: number };
+
+function attachContenteditable(el: HTMLElement) {
+  if (editors.has(el)) return;
+  if (el.closest(`.${HOST_CLASS}`)) return;
+  if (el.hasAttribute('data-slop-ignore')) return;
+  // Don't re-attach to an element already inside an attached contenteditable
+  // (nested ce elements are rare but real: e.g. Gmail quote blocks).
+  for (const ed of editorRegistry) {
+    if (ed !== el && ed.contains(el)) return;
+  }
+  // Minimum visible size guard so we don't attach to empty 0-height divs that
+  // become contenteditable only when clicked.
+  const rect = el.getBoundingClientRect();
+  if (rect.width < 120 || rect.height < 16) return;
+
+  const badge = document.createElement('span');
+  badge.className = `${HOST_CLASS} ${BADGE_CLASS} lsd-hidden`;
+  badge.textContent = '0';
+  badge.title = 'LLM Slop Detector';
+  badge.setAttribute('role', 'button');
+  badge.setAttribute('tabindex', '0');
+  badge.addEventListener('click', e => { e.stopPropagation(); togglePopover(el); });
+  badge.addEventListener('keydown', e => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); togglePopover(el); }
+  });
+  document.body.appendChild(badge);
+
+  const state: EditorState = {
+    editor: el,
+    kind: 'contenteditable',
+    badge,
+    mirror: null,
+    marks: [],
+    applyingMarks: false,
+    debounceHandle: null,
+    lastFindings: [],
+    lastText: '',
+    resizeObserver: null,
+  };
+  editors.set(el, state);
+  editorRegistry.add(el);
+
+  el.addEventListener('input', () => {
+    // input fires on our own wrap mutations too (via execCommand fix and
+    // the native DOM mutations). Skip when we know we caused it.
+    if (state.applyingMarks) return;
+    scheduleScan(state);
+  });
+  el.addEventListener('focus', () => positionOverlays(state));
+  el.addEventListener('blur', () => {
+    setTimeout(() => { if (document.activeElement !== badge) positionOverlays(state); }, 150);
+  });
+
+  if ('ResizeObserver' in window) {
+    state.resizeObserver = new ResizeObserver(() => reflowAll());
+    state.resizeObserver.observe(el);
+  }
+
+  installGlobalListeners();
+  positionOverlays(state);
+  runScanCe(state);
+}
+
+// Extract plain text from a contenteditable, alongside a fragment map from
+// the extracted-text offset space back to the DOM text nodes. Our own
+// <lsd-ce-mark> wrappers are descended into but produce no extra text, so
+// the extracted string is stable across mark presence/absence.
+function extractCeText(el: HTMLElement): { text: string; fragments: CeFragment[] } {
+  let text = '';
+  const fragments: CeFragment[] = [];
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const t = node as Text;
+      fragments.push({ node: t, textOffset: text.length });
+      text += t.nodeValue ?? '';
+      return;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return;
+    const elNode = node as Element;
+    const tag = elNode.tagName.toLowerCase();
+    if (tag === 'br') { text += '\n'; return; }
+    if (CE_EXTRACT_SKIP.has(tag)) return;
+    // Our own marker: descend transparently so extracted text ignores it.
+    const isOurMark = tag === CE_MARK_TAG;
+    const block = !isOurMark && isBlockElement(elNode);
+    if (block && text.length > 0 && !text.endsWith('\n')) text += '\n';
+    for (const child of Array.from(elNode.childNodes)) walk(child);
+    if (block && !text.endsWith('\n')) text += '\n';
+  };
+
+  for (const child of Array.from(el.childNodes)) walk(child);
+  return { text, fragments };
+}
+
+function isBlockElement(el: Element): boolean {
+  const display = getComputedStyle(el).display;
+  // Treat grid/flex containers as block for text-flow purposes too.
+  return display === 'block' || display === 'flex' || display === 'grid' || display === 'list-item' || display === 'table';
+}
+
+function findFragmentAt(fragments: CeFragment[], textOffset: number): { frag: CeFragment; localOffset: number } | null {
+  // Binary search would be nicer; linear is fine for typical fragment counts.
+  for (let i = 0; i < fragments.length; i++) {
+    const f = fragments[i];
+    const len = f.node.nodeValue?.length ?? 0;
+    const end = f.textOffset + len;
+    if (textOffset >= f.textOffset && textOffset <= end) {
+      return { frag: f, localOffset: textOffset - f.textOffset };
+    }
+  }
+  return null;
+}
+
+function wrapCeFinding(fragments: CeFragment[], f: Finding, state: EditorState): HTMLElement | null {
+  const start = findFragmentAt(fragments, f.offset);
+  const end = findFragmentAt(fragments, f.offset + f.length);
+  if (!start || !end) return null;
+
+  // Same-text-node fast path.
+  if (start.frag === end.frag) {
+    return wrapCeRange(start.frag.node, start.localOffset, end.frag.node, end.localOffset, f);
+  }
+
+  // Cross-text-node: try a range that crosses element boundaries. Some will
+  // fail via surroundContents (ranges that partially contain non-text nodes).
+  return wrapCeRange(start.frag.node, start.localOffset, end.frag.node, end.localOffset, f);
+}
+
+function wrapCeRange(startNode: Text, startOffset: number, endNode: Text, endOffset: number, f: Finding): HTMLElement | null {
+  try {
+    const range = document.createRange();
+    range.setStart(startNode, startOffset);
+    range.setEnd(endNode, endOffset);
+    const wrapper = document.createElement(CE_MARK_TAG);
+    wrapper.className = `${CE_MARK_TAG} lsd-sev-${f.severity}`;
+    wrapper.setAttribute('data-lsd-message', f.message);
+    wrapper.setAttribute('data-lsd-offset', String(f.offset));
+    range.surroundContents(wrapper);
+    return wrapper;
+  } catch {
+    // Range crosses element boundaries (e.g. inline formatting splits the
+    // phrase). Skipping the mark here means the finding still appears in
+    // the popover's list, just without an inline mark. Acceptable v1.
+    return null;
+  }
+}
+
+function unwrapCeMarks(state: EditorState) {
+  for (const m of state.marks) {
+    const parent = m.parentNode;
+    if (!parent) continue;
+    while (m.firstChild) parent.insertBefore(m.firstChild, m);
+    parent.removeChild(m);
+  }
+  state.marks = [];
+  // Coalesce adjacent text nodes so next scan's fragment offsets are tidy.
+  (state.editor as HTMLElement).normalize?.();
+}
+
+function getCeCaretOffset(fragments: CeFragment[]): number | null {
+  const sel = window.getSelection();
+  if (!sel || sel.rangeCount === 0) return null;
+  const r = sel.getRangeAt(0);
+  if (!r.collapsed) return null; // only preserve collapsed caret
+  if (r.startContainer.nodeType !== Node.TEXT_NODE) return null;
+  const node = r.startContainer as Text;
+  for (const f of fragments) {
+    if (f.node === node) return f.textOffset + r.startOffset;
+  }
+  return null;
+}
+
+function setCeCaretOffset(fragments: CeFragment[], targetOffset: number) {
+  const hit = findFragmentAt(fragments, targetOffset);
+  if (!hit) return;
+  try {
+    const range = document.createRange();
+    range.setStart(hit.frag.node, hit.localOffset);
+    range.setEnd(hit.frag.node, hit.localOffset);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+  } catch { /* ignore */ }
+}
+
+function findingsEqual(a: Finding[], b: Finding[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].offset !== b[i].offset || a[i].length !== b[i].length || a[i].matchText !== b[i].matchText) return false;
+  }
+  return true;
+}
+
+function runScanCe(state: EditorState) {
+  const el = state.editor as HTMLElement;
+  if (!document.contains(el)) {
+    state.badge.remove();
+    state.resizeObserver?.disconnect();
+    editors.delete(el);
+    editorRegistry.delete(el);
+    return;
+  }
+
+  const { text, fragments } = extractCeText(el);
+  state.lastText = text;
+
+  if (text.length > SIZE_CAP) {
+    state.lastFindings = [];
+    updateBadge(state, -1);
+    if (state.marks.length > 0) {
+      state.applyingMarks = true;
+      unwrapCeMarks(state);
+      state.applyingMarks = false;
+    }
+    return;
+  }
+
+  const findings = scanText(text, rules, LANGUAGE);
+
+  if (findingsEqual(findings, state.lastFindings)) {
+    // Text may have changed (user typed whitespace) but findings are the
+    // same -- skip the DOM dance to avoid flickering marks.
+    state.lastFindings = findings;
+    updateBadge(state, findings.length);
+    if (popover && activeEditorEl === el) renderPopover(state);
+    return;
+  }
+
+  state.lastFindings = findings;
+  updateBadge(state, findings.length);
+
+  const caretOffset = getCeCaretOffset(fragments);
+
+  state.applyingMarks = true;
+  unwrapCeMarks(state);
+  const { fragments: fresh } = extractCeText(el);
+  // Wrap right-to-left so earlier offsets stay valid across splits.
+  const sorted = [...findings].sort((a, b) => b.offset - a.offset);
+  const wrapped: HTMLElement[] = [];
+  let minStart = Infinity;
+  for (const f of sorted) {
+    if (f.offset + f.length > minStart) continue;
+    const mark = wrapCeFinding(fresh, f, state);
+    if (mark) {
+      wrapped.push(mark);
+      minStart = f.offset;
+    }
+  }
+  state.marks = wrapped;
+  state.applyingMarks = false;
+
+  if (caretOffset !== null) {
+    const { fragments: final } = extractCeText(el);
+    setCeCaretOffset(final, caretOffset);
+  }
+
+  if (popover && activeEditorEl === el) renderPopover(state);
 }
 
 let globalListenersInstalled = false;
@@ -276,6 +573,13 @@ function processHover(x: number, y: number) {
     showTooltip(msg, x, y, key);
     return;
   }
+  const ceHit = findCeMarkAtPoint(x, y);
+  if (ceHit) {
+    const key = `ce:${ceHit.offset}`;
+    const msg = ceHit.mark.getAttribute('data-lsd-message') || '';
+    showTooltip(msg, x, y, key);
+    return;
+  }
   const rdHit = findRdMarkAtPoint(x, y);
   if (rdHit) {
     const key = `rd:${rdHit.index}`;
@@ -300,11 +604,39 @@ function onDocClick(e: MouseEvent) {
     return;
   }
 
+  const ceHit = findCeMarkAtPoint(e.clientX, e.clientY);
+  if (ceHit) {
+    const state = ceHit.state;
+    if (!popover || activeEditorEl !== state.editor) openPopover(state);
+    if (ceHit.offset >= 0) highlightPopoverFinding(ceHit.offset);
+    return;
+  }
+
   const rdHit = findRdMarkAtPoint(e.clientX, e.clientY);
   if (rdHit) {
     jumpToRdFinding(rdHit);
     return;
   }
+}
+
+function findCeMarkAtPoint(x: number, y: number): { state: EditorState; mark: HTMLElement; offset: number } | null {
+  for (const ed of editorRegistry) {
+    const s = editors.get(ed);
+    if (!s || s.kind !== 'contenteditable') continue;
+    if (s.marks.length === 0) continue;
+    const outer = (s.editor as HTMLElement).getBoundingClientRect();
+    if (x < outer.left || x > outer.right || y < outer.top || y > outer.bottom) continue;
+    for (const mark of s.marks) {
+      const rects = mark.getClientRects();
+      for (const r of rects) {
+        if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+          const offset = parseInt(mark.getAttribute('data-lsd-offset') || '-1', 10);
+          return { state: s, mark, offset };
+        }
+      }
+    }
+  }
+  return null;
 }
 
 function findRdMarkAtPoint(x: number, y: number): RdFinding | null {
@@ -400,12 +732,14 @@ function scheduleScan(state: EditorState) {
   if (state.debounceHandle !== null) window.clearTimeout(state.debounceHandle);
   state.debounceHandle = window.setTimeout(() => {
     state.debounceHandle = null;
-    runScan(state);
+    if (state.kind === 'contenteditable') runScanCe(state);
+    else runScan(state);
   }, DEBOUNCE_MS);
 }
 
 function runScan(state: EditorState) {
-  const text = state.editor.value ?? '';
+  const editor = state.editor as TextControl;
+  const text = editor.value ?? '';
   state.lastText = text;
   if (text.length > SIZE_CAP) {
     state.lastFindings = [];
@@ -580,7 +914,7 @@ function renderMarkFragments(f: Finding): string {
 // Popover
 // ---------------------------------------------------------------------------
 
-function togglePopover(editor: HTMLTextAreaElement | HTMLInputElement) {
+function togglePopover(editor: EditorEl) {
   if (popover && activeEditorEl === editor) {
     closePopover();
     return;
@@ -722,23 +1056,30 @@ function highlightPopoverFinding(offset: number) {
 
 function setEditorValue(state: EditorState, next: string): void {
   // Use the native value setter so React / Vue / Lit see the change.
+  const editor = state.editor as TextControl;
   const proto = state.kind === 'textarea'
     ? HTMLTextAreaElement.prototype
     : HTMLInputElement.prototype;
   const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
   if (setter) {
-    setter.call(state.editor, next);
+    setter.call(editor, next);
   } else {
-    state.editor.value = next;
+    editor.value = next;
   }
-  state.editor.dispatchEvent(new Event('input', { bubbles: true }));
+  editor.dispatchEvent(new Event('input', { bubbles: true }));
 }
 
 function applyCharFix(state: EditorState, finding: Finding) {
   if (finding.code !== 'char') return;
   const def = rules.chars.get(finding.matchText);
   if (!def || def.replacement === undefined) return;
-  const { editor } = state;
+
+  if (state.kind === 'contenteditable') {
+    applyCeCharFix(state, finding, def.replacement);
+    return;
+  }
+
+  const editor = state.editor as TextControl;
   const current = editor.value;
   const next = current.slice(0, finding.offset) + def.replacement + current.slice(finding.offset + finding.length);
   setEditorValue(state, next);
@@ -749,8 +1090,7 @@ function applyCharFix(state: EditorState, finding: Finding) {
 }
 
 function applyAllCharFixes(state: EditorState) {
-  // Apply right-to-left so earlier offsets stay valid as we mutate.
-  const fixes = state.lastFindings
+  const fixable = state.lastFindings
     .filter(f => f.code === 'char')
     .map(f => {
       const def = rules.chars.get(f.matchText);
@@ -759,17 +1099,56 @@ function applyAllCharFixes(state: EditorState) {
         : null;
     })
     .filter((x): x is { offset: number; length: number; replacement: string } => x !== null)
-    .sort((a, b) => b.offset - a.offset);
+    .sort((a, b) => b.offset - a.offset); // right-to-left preserves offsets
 
-  if (fixes.length === 0) return;
+  if (fixable.length === 0) return;
 
-  let next = state.editor.value;
-  for (const fx of fixes) {
+  if (state.kind === 'contenteditable') {
+    // Apply each one via execCommand so the undo stack sees N discrete
+    // edits. Doing a single big insertText would lose finding-level undo.
+    const el = state.editor as HTMLElement;
+    el.focus();
+    for (const fx of fixable) applyCeFixAtOffset(el, fx.offset, fx.length, fx.replacement);
+    // scheduleScan will fire via input events; no extra rescan needed.
+    return;
+  }
+
+  const editor = state.editor as TextControl;
+  let next = editor.value;
+  for (const fx of fixable) {
     next = next.slice(0, fx.offset) + fx.replacement + next.slice(fx.offset + fx.length);
   }
   setEditorValue(state, next);
-  state.editor.focus();
-  // runScan runs via the dispatched input event.
+  editor.focus();
+}
+
+function applyCeCharFix(state: EditorState, finding: Finding, replacement: string) {
+  const el = state.editor as HTMLElement;
+  el.focus();
+  applyCeFixAtOffset(el, finding.offset, finding.length, replacement);
+}
+
+// Sets the selection to the given extracted-text offset range inside a
+// contenteditable and runs execCommand('insertText'). Using execCommand
+// instead of direct DOM surgery preserves the undo stack (Cmd+Z in Gmail
+// works naturally) and lets the host framework react via its own input
+// handler.
+function applyCeFixAtOffset(el: HTMLElement, offset: number, length: number, replacement: string) {
+  const { fragments } = extractCeText(el);
+  const start = findFragmentAt(fragments, offset);
+  const end = findFragmentAt(fragments, offset + length);
+  if (!start || !end) return;
+  try {
+    const range = document.createRange();
+    range.setStart(start.frag.node, start.localOffset);
+    range.setEnd(end.frag.node, end.localOffset);
+    const sel = window.getSelection();
+    sel?.removeAllRanges();
+    sel?.addRange(range);
+    // execCommand is deprecated but remains the only reliable way to
+    // insert text into a contenteditable while preserving the undo stack.
+    document.execCommand('insertText', false, replacement);
+  } catch { /* selection failed; skip */ }
 }
 
 // ---------------------------------------------------------------------------
@@ -1015,6 +1394,22 @@ function injectStyles() {
       display: inline-block !important;
     }
     .${POPOVER_CLASS} .lsd-fix:hover { background: rgba(127,127,127,0.3) !important; }
+
+    /* ---- Contenteditable marks ---- */
+    ${CE_MARK_TAG} {
+      /* Wavy underline that matches the read-only mark style: keeps the
+         text legible in a writing context and doesn't disturb selection
+         gestures since we leave pointer-events at default (but clicks
+         bubble through to the contenteditable). */
+      text-decoration: underline wavy !important;
+      text-underline-offset: 2px !important;
+      text-decoration-thickness: 1.5px !important;
+      pointer-events: none !important;
+    }
+    ${CE_MARK_TAG}.lsd-sev-error       { text-decoration-color: #d73a49 !important; }
+    ${CE_MARK_TAG}.lsd-sev-warning     { text-decoration-color: #b08800 !important; }
+    ${CE_MARK_TAG}.lsd-sev-information { text-decoration-color: #0366d6 !important; }
+    ${CE_MARK_TAG}.lsd-sev-hint        { text-decoration-color: #6a737d !important; }
 
     /* ---- Read-only page scan ---- */
     ${RD_MARK_TAG} {


### PR DESCRIPTION
## Summary

Adds a second attach path so the extension also scans plain \`contenteditable\` elements (Gmail compose, vanilla rich-text widgets). Badge + popover + hover tooltip + click-to-jump + fix-this / fix-all-chars all work on the new path, sharing the existing infrastructure.

Closes #71.

## What landed

- **Discovery**: \`scanDocument\` / \`observeMutations\` now also match \`[contenteditable=\"true\"]\` and \`[contenteditable=\"\"]\`. Skip nested ce (e.g. Gmail quote blocks inside the compose root) by rejecting any editor whose ancestor is already attached. Minimum-size guard for 0-height widgets.
- **State**: \`EditorKind\` widened to include \`'contenteditable'\` and \`EditorState\` now accepts \`HTMLElement\` editors with \`marks[]\` + \`applyingMarks\` fields used only by the ce path.
- **Text extraction**: walks the ce element's children and reconstructs plain text with \`\\n\` for \`<br>\` and block-level transitions. Our own \`<lsd-ce-mark>\` wrappers are descended into but produce no extra text, so the extracted string is stable regardless of mark presence -- scans don't change findings just because we wrapped.
- **Range wrapping** via \`Range.surroundContents\` with a custom element tag (\`<lsd-ce-mark>\`, not \`<span>\`) so host-page selectors like \`.parent > span\` don't accidentally target our marks. Same-text-node fast path plus a cross-text-node fallback that tries \`surroundContents\` and skips gracefully if it throws (happens when the range spans inline formatting boundaries -- finding still shows in the popover list, just without an inline mark).
- **Selection preservation**: save the caret offset (in extracted-text space) before unwrap+rewrap, restore via the fresh fragment map after. Only rewraps when findings changed -- if the user types whitespace, findings are identical and we skip the DOM mutation entirely to avoid cursor flicker.
- **Fix application** via \`document.execCommand('insertText')\` after \`setBaseAndExtent\`. Deprecated, but the only reliable way to insert text while preserving the ce's undo stack so \`Cmd+Z\` in Gmail undoes the fix as one natural step.
- **Hover tooltip + click-to-jump**: \`findCeMarkAtPoint\` hit-tests via \`getClientRects\`, integrated into \`processHover\` / \`onDocClick\` (order: editor mirror marks -> ce marks -> read-only marks). Marks use \`pointer-events: none\` so clicks fall through to the contenteditable for native selection/caret.
- **CSS**: wavy underline in severity colours (not a background tint) so styled rich-text content underneath stays legible. Matches the read-only-mark style.

## Design choices

- **No MutationObserver on the ce element.** Only the \`input\` event. Programmatic changes by host editors (Gmail autocomplete, etc.) that don't fire \`input\` will leave marks stale until the next keystroke. The loop-risk of observing our own mutations, and the complexity of an \`applyingMarks\` guard that works across frameworks, wasn't worth it for v1.
- **Cross-boundary ranges skip rather than split.** When a phrase straddles inline formatting (\`<em>\`, \`<a>\`, etc.), \`surroundContents\` throws. Per-fragment splitting is doable but doubles the DOM dance. For v1 the finding still appears in the popover; the README documents this.
- **No \`<lsd-ce-mark>\` rewrap retries.** Rich editors that reconcile our marks away (Notion/Substack/LinkedIn/Twitter) degrade to badge-only. Adding a re-wrap observer risks a reconciliation loop. Better to ship as-is, see where users hit it, and target individual frameworks with bespoke handling later.

## Test plan

- [x] \`npx tsc -p extension-browser/tsconfig.json\` clean.
- [x] \`npm run build:browser\` produces ~121 KB content.js.
- [x] Dog-fooded in Arc on a local test harness:
  - Plain ce div with slop text -> badge + wavy underlines under flagged words/phrases.
  - Typing new slop into an empty ce -> marks appear on pause (~150ms debounce).
  - Caret stays in place while typing; no visible flicker.
  - Click on an underlined word -> popover opens, the matching finding pulses blue.
  - Hover -> dark tooltip with rule message.
  - Double-click to select a word under a mark -> still selects natively (marks are pointer-transparent).
  - Textarea path still works unchanged (sanity check).
  - Fix-all on char findings -> replacement via execCommand, \`Cmd+Z\` undoes one at a time.
  - Phrase that straddles \`<em>\` formatting -> appears in popover list; no inline mark (documented).
- [ ] **Reviewer: retest in Firefox and verify in a real Gmail compose window.** I tested Arc on a local harness; Gmail's own DOM has additional quirks (its compose root is a deeply-nested \`contenteditable\` inside an iframe on some account types) that may need follow-up tweaks.

## README

Moved from \"known limitations\": contenteditable. Kept as known limitations: rich editors with virtual-DOM reconcilers (Notion/Substack/LinkedIn/Twitter) which strip marks on reconcile; canvas-rendered editors (Google Docs); cross-origin iframes; phrase matches that cross inline formatting boundaries.

## Files

- Modified: \`extension-browser/src/content.ts\` (+395 lines), \`README.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)