### PR TITLE
fix: Chrome Web Store submission (description length + single-purpose doc)

### DIFF
--- a/docs/STORE_SUBMISSION.md
+++ b/docs/STORE_SUBMISSION.md
@@ -13,6 +13,34 @@ npm run package:browser
 
 Upload the same zip to all three stores.
 
+## Single-purpose description (1000 char max, Chrome)
+
+Chrome policy requires a single narrow purpose that every feature serves.
+
+```
+The extension has one purpose: identify and help the user clean up text
+that carries LLM-generation fingerprints -- invisible Unicode, AI-style
+punctuation (em dashes, curly quotes, ellipses), and a curated list of
+phrase patterns that large language models produce far more often than
+humans do (e.g. "delve", "tapestry of", "it's worth noting",
+"game-changing", "cutting-edge").
+
+Every feature serves that single purpose:
+
+- Inline marks surface flagged text in any editable field the user is
+  writing in (textarea, input, contenteditable). Hover or click the
+  mark to see the rule that fired.
+- A "Scan this page" button runs the same detector on the page's
+  visible text, so the user can evaluate content they're reading with
+  the same criteria they apply to their own drafts.
+- A fix-all action rewrites the flagged punctuation to plain-ASCII
+  equivalents -- a direct remediation of the same findings the
+  detector produced.
+
+All processing is local; the extension never transmits text off the
+user's device, never contacts any server, and ships no telemetry.
+```
+
 ## Short description (132 char max, Chrome)
 
 > Flags invisible Unicode, AI-style punctuation, and telltale LLM phrases as you type -- or in any page you're reading. Local only.

--- a/extension-browser/manifest.json
+++ b/extension-browser/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "LLM Slop Detector",
   "version": "0.8.0",
-  "description": "Highlights invisible Unicode, AI-style punctuation, and telltale LLM phrases as you type in any textarea on the web. Runs entirely in your browser.",
+  "description": "Flags invisible Unicode, AI-style punctuation, and telltale LLM phrases as you type -- or in any page you're reading. Local only.",
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
## Summary

Two small fixes that came up during the first Chrome Web Store upload attempt:

1. **Shorten the manifest description** from 147 to 129 chars. Chrome's rejection message:
   > The description field in manifest is too long: 147. It exceeds the maximum size limit of 132 characters.
2. **Add the Chrome single-purpose statement** to \`docs/STORE_SUBMISSION.md\`. Chrome requires a separate 1000-char \"single purpose\" field at submission time -- drafted once, stored in the repo so we don't rewrite it on every resubmit.

## Manifest description

Before (147 chars):
> Highlights invisible Unicode, AI-style punctuation, and telltale LLM phrases as you type in any textarea on the web. Runs entirely in your browser.

After (129 chars):
> Flags invisible Unicode, AI-style punctuation, and telltale LLM phrases as you type -- or in any page you're reading. Local only.

This is the same wording as the \"Short description\" we already had in \`docs/STORE_SUBMISSION.md\`, so both the manifest field and the store-listing short description are now one string.

## Single-purpose statement

968 chars. Maps each extension feature (inline marks, page scan, fix-all) to the one stated purpose so reviewers can see every feature serves it:

```
The extension has one purpose: identify and help the user clean up text
that carries LLM-generation fingerprints -- invisible Unicode, AI-style
punctuation (em dashes, curly quotes, ellipses), and a curated list of
phrase patterns that large language models produce far more often than
humans do (...).
Every feature serves that single purpose: [inline marks / Scan this
page / fix-all].
All processing is local; the extension never transmits text off the
user's device, never contacts any server, and ships no telemetry.
```

Full text lives in \`docs/STORE_SUBMISSION.md\`.

## Test plan

- [x] \`python3\` length check on manifest description: 129 chars, under 132.
- [x] \`npm run package:browser\` produces \`llm-slop-detector-browser-0.8.0.zip\` with the updated manifest.
- [ ] **Reviewer**: retry the Chrome Web Store upload with the new zip and paste the single-purpose text.

## Files

- Modified: \`extension-browser/manifest.json\` (description shortened), \`docs/STORE_SUBMISSION.md\` (new single-purpose section)

🤖 Generated with [Claude Code](https://claude.com/claude-code)