### PR TITLE
feat: skip NBSP detection in rich-text editors by default

### DIFF
--- a/extension-browser/src/content.ts
+++ b/extension-browser/src/content.ts
@@ -482,6 +482,17 @@ function setCeCaretOffset(fragments: CeFragment[], targetOffset: number) {
   } catch { /* ignore */ }
 }
 
+// Browser contenteditable engines (Gmail, Proton, Outlook, Slack, Discord, ...)
+// auto-insert U+00A0 / U+202F between words as a layout trick to keep
+// whitespace from collapsing. They're a render artifact, not what gets sent
+// over the wire, so flagging every word boundary just adds noise. We drop
+// these specific findings inside contenteditables unless the user opts in
+// via Options.
+function filterRichTextFindings(findings: Finding[]): Finding[] {
+  if (prefs.detectNbspInRichText) return findings;
+  return findings.filter(f => f.matchText !== '\u00A0' && f.matchText !== '\u202F');
+}
+
 function findingsEqual(a: Finding[], b: Finding[]): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {
@@ -514,7 +525,7 @@ function runScanCe(state: EditorState) {
     return;
   }
 
-  const findings = scanText(text, rules, LANGUAGE);
+  const findings = filterRichTextFindings(scanText(text, rules, LANGUAGE));
 
   if (findingsEqual(findings, state.lastFindings)) {
     // Text may have changed (user typed whitespace) but findings are the

--- a/extension-browser/src/options.html
+++ b/extension-browser/src/options.html
@@ -20,6 +20,15 @@
     </section>
 
     <section>
+      <h2>Rich-text editors</h2>
+      <p class="hint">Browser rich-text editors (Gmail, Proton Mail, Outlook, Slack, Discord, etc.) routinely insert non-breaking spaces between words as a layout trick -- they're not in the message you actually send. By default we hide NBSP / narrow-NBSP findings inside <code>contenteditable</code> fields to keep the noise down. Other invisible characters and AI-style punctuation are still flagged everywhere.</p>
+      <label class="toggle">
+        <input type="checkbox" id="nbsp-richtext-enabled">
+        <span>Detect non-breaking spaces in rich-text editors</span>
+      </label>
+    </section>
+
+    <section>
       <h2>Rule packs</h2>
       <p class="hint">Core rules are always on. Packs add extra model-specific or domain-specific phrases.</p>
       <div id="packs" class="packs"></div>

--- a/extension-browser/src/options.ts
+++ b/extension-browser/src/options.ts
@@ -67,17 +67,23 @@ async function init() {
   const packsEl = $('packs');
   const hostsEl = $('disabled-hosts');
   const roToggle = $('readonly-enabled') as HTMLInputElement;
+  const nbspToggle = $('nbsp-richtext-enabled') as HTMLInputElement;
   renderPacks(packsEl, prefs);
   renderDisabledHosts(hostsEl, prefs);
   roToggle.checked = prefs.readOnlyEnabled;
+  nbspToggle.checked = prefs.detectNbspInRichText;
   roToggle.addEventListener('change', async () => {
     await updatePrefs({ readOnlyEnabled: roToggle.checked });
+  });
+  nbspToggle.addEventListener('change', async () => {
+    await updatePrefs({ detectNbspInRichText: nbspToggle.checked });
   });
   onPrefsChanged(next => {
     prefs = next;
     renderPacks(packsEl, prefs);
     renderDisabledHosts(hostsEl, prefs);
     roToggle.checked = prefs.readOnlyEnabled;
+    nbspToggle.checked = prefs.detectNbspInRichText;
   });
 }
 

--- a/extension-browser/src/storage.ts
+++ b/extension-browser/src/storage.ts
@@ -11,6 +11,7 @@ export type Prefs = {
   enabledPacks: string[];
   disabledHosts: string[];
   readOnlyEnabled: boolean;
+  detectNbspInRichText: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -18,6 +19,7 @@ export const DEFAULTS: Prefs = {
   enabledPacks: [],
   disabledHosts: [],
   readOnlyEnabled: true,
+  detectNbspInRichText: false,
 };
 
 const KEY = 'prefs';
@@ -34,6 +36,7 @@ export async function getPrefs(): Promise<Prefs> {
       ? (stored!.disabledHosts as unknown[]).filter((x): x is string => typeof x === 'string')
       : DEFAULTS.disabledHosts,
     readOnlyEnabled: typeof stored?.readOnlyEnabled === 'boolean' ? stored.readOnlyEnabled : DEFAULTS.readOnlyEnabled,
+    detectNbspInRichText: typeof stored?.detectNbspInRichText === 'boolean' ? stored.detectNbspInRichText : DEFAULTS.detectNbspInRichText,
   };
 }
 


### PR DESCRIPTION
## Summary
- Drop U+00A0 / U+202F findings inside contenteditables before they reach the popover, badge, and inline marks. Browser rich-text engines (Gmail, Proton Mail, Outlook web, Slack, Discord, ...) auto-insert these between words to keep whitespace from collapsing -- they don't end up in the message you actually send, so flagging every word boundary just produces noise.
- Other invisible characters (zero-width chars, BOM, RTL marks) and AI-style punctuation still fire everywhere. Textareas, plain inputs, and the read-only page-scan flow are unchanged.
- Add an opt-in "Detect non-breaking spaces in rich-text editors" toggle in Options (default off) for anyone who wants the previous behavior.

## Why
Reported while composing in Proton: every space between words got squiggled. Confirmed via hover that the squiggles were real U+00A0 -- not a bug, just contenteditable's well-known whitespace-preservation trick. Pasting the same text into VS Code came back clean because the clipboard normalized the NBSPs out, which is also the typical fate of these characters when the email is serialized and sent.

## Test plan
- [ ] Load `extension-browser-dist/` as an unpacked extension.
- [ ] Open a Proton Mail compose window, type a sentence, confirm no per-space squiggles.
- [ ] Repeat in Gmail compose -- confirm no squiggles.
- [ ] Paste a string containing zero-width space / BOM / em-dash / smart quote into the same compose field -- confirm those still flag.
- [ ] In a regular `<textarea>` (e.g. a GitHub comment box), type or paste an NBSP -- confirm it still flags (the filter is contenteditable-only).
- [ ] Open the extension Options, toggle "Detect non-breaking spaces in rich-text editors" on, return to Proton compose -- squiggles return immediately (live rescan via existing `onPrefsChanged`).
- [ ] Toggle off again -- squiggles disappear.
- [ ] Read-only page scan (toolbar action) on a page containing NBSPs still flags them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)