### PR TITLE
docs: link Chrome Web Store and Firefox AMO listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # LLM Slop Detector
 
 [![Install on VS Code Marketplace](https://img.shields.io/badge/VS%20Code-Marketplace-blue?logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=thias-se.llm-slop-detector)
+[![Install on Chrome Web Store](https://img.shields.io/badge/Chrome-Web%20Store-4285F4?logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/llm-slop-detector/ancpfnfeflffphhpaejhpggfhjmafeid)
+[![Install on Firefox Add-ons](https://img.shields.io/badge/Firefox-Add--ons-FF7139?logo=firefox&logoColor=white)](https://addons.mozilla.org/en-US/firefox/addon/llm-slop-detector/)
 [![License: MIT](https://img.shields.io/github/license/mandakan/llm-slop-detector)](LICENSE)
 
 A VS Code extension and CLI that flag invisible Unicode, AI-style punctuation, and telltale LLM phrases in `markdown` and `plaintext` files. The CLI shares its rule engine with the editor, so local and CI findings stay in sync.
@@ -15,7 +17,12 @@ No install needed -- paste text into the [web playground](https://mandakan.githu
 
 A WebExtension that scans `<textarea>`, text inputs, and `contenteditable` elements (Gmail compose, vanilla rich-text widgets) as you type on any webpage. Findings are highlighted inline with colour-coded marks -- textarea marks are tinted background, contenteditable marks are wavy underlines so they don't disturb reading of styled content. A small "N slop" badge next to each editor opens a per-finding popover with severity, reason, source pack, per-finding "Fix this" buttons, and a "Fix all chars" button that applies every deterministic character replacement (em dash, curly quotes, zero-width, etc.) at once. For contenteditables the fix goes through `execCommand('insertText')` so the host editor's undo stack still works (`Cmd+Z`). Runs entirely in the browser -- no network calls, no telemetry.
 
-**Install from source (until stores are wired up):**
+**Install from a store:**
+
+- **Chrome / Arc / Edge / Brave:** [Chrome Web Store listing](https://chromewebstore.google.com/detail/llm-slop-detector/ancpfnfeflffphhpaejhpggfhjmafeid). Chromium forks accept the same package.
+- **Firefox:** [Firefox Add-ons listing](https://addons.mozilla.org/en-US/firefox/addon/llm-slop-detector/).
+
+**Install from source (for hacking on the rules):**
 
 ```sh
 npm ci

--- a/docs/STORE_SUBMISSION.md
+++ b/docs/STORE_SUBMISSION.md
@@ -124,6 +124,9 @@ answers ready to paste into the form:
 
 ## URLs
 
+- Chrome Web Store listing: `https://chromewebstore.google.com/detail/llm-slop-detector/ancpfnfeflffphhpaejhpggfhjmafeid`
+- Firefox AMO listing: `https://addons.mozilla.org/en-US/firefox/addon/llm-slop-detector/`
+- Edge Add-ons listing: (not yet submitted)
 - Privacy policy: `https://mandakan.github.io/llm-slop-detector/privacy.html`
 - Support site / homepage: `https://github.com/mandakan/llm-slop-detector`
 - Source code: same as above (MIT-licensed)


### PR DESCRIPTION
## Summary
- Add Chrome Web Store and Firefox AMO badges to the README alongside the VS Code Marketplace badge.
- Rework the browser-extension section so the store install links come first and "load unpacked" is framed as the dev path.
- Record the canonical Chrome and AMO listing URLs in `docs/STORE_SUBMISSION.md`.

Both listings are now live:
- Chrome: https://chromewebstore.google.com/detail/llm-slop-detector/ancpfnfeflffphhpaejhpggfhjmafeid
- Firefox: https://addons.mozilla.org/en-US/firefox/addon/llm-slop-detector/

## Test plan
- [ ] README renders correctly on GitHub (badges, section order).
- [ ] Both store links resolve to the live listings.
- [ ] No version bump expected (release-please should ignore a `docs:` commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)