### PR TITLE
feat: add puffery pack for promotional LLM phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Turn this off in the options page if you only want to lint your own writing. The
 
 - Flags zero-width, BOM, non-breaking spaces, and other invisible Unicode that hides in text and wrecks diffs
 - Flags AI-style punctuation: em and en dashes, curly quotes, horizontal ellipsis, angle quotes
-- Configurable phrase rules: ~40 built-in core rules plus twelve opt-in packs (`academic`, `cliches`, `fiction`, `claudeisms`, `structural`, `security`, `openai`, `gemini`, `deepseek`, `llama`, `qwen`, `grok`) totalling 500+ curated regex patterns
+- Configurable phrase rules: ~40 built-in core rules plus thirteen opt-in packs (`academic`, `cliches`, `puffery`, `fiction`, `claudeisms`, `structural`, `security`, `openai`, `gemini`, `deepseek`, `llama`, `qwen`, `grok`) totalling 500+ curated regex patterns
 - Markdown-aware: skips fenced and inline code, link URLs, and YAML frontmatter so technical prose doesn't drown in false positives
 - Inline-ignore comments (`<!-- slop-disable -->`, `<!-- slop-disable-next-line -->`, `<!-- slop-disable-line -->`) for one-off exceptions
 - Hover over any flagged range for the rule selector plus a ready-to-copy `slop-disable-next-line` snippet
@@ -188,6 +188,7 @@ The core list is deliberately conservative: ~40 phrase rules covering the buzzwo
 
 - **`academic`** -- words over-represented in LLM-authored academic writing (`bolster`, `elucidate`, `facilitate`, `showcase`, `noteworthy`, ~90 entries). Severity `hint` so the Problems panel stays usable. Derived from [`berenslab/llm-excess-vocab`](https://github.com/berenslab/llm-excess-vocab) (MIT).
 - **`cliches`** -- general LLM cliche vocabulary (`captivating`, `pinnacle`, `galvanize`, journey/landscape/symphony metaphors). Derived from [`nanxstats/llm-cliches`](https://github.com/nanxstats/llm-cliches) (MIT).
+- **`puffery`** -- promotional / editorializing puffery: `rich cultural heritage`, `nestled in the heart of`, `boasts`, `enduring legacy`, `leaves an indelible mark`, `deeply rooted`, `diverse array of`, copula-avoidance flourishes. Original content.
 - **`fiction`** -- fiction and creative-writing tells (breath hitched, heart hammering, shivers down spine, chestnut eyes, LLM-cliche character names). **Includes adult-fiction markers.** Derived from [`SicariusSicariiStuff/SLOP_Detector`](https://github.com/SicariusSicariiStuff/SLOP_Detector) (Apache-2.0).
 - **`claudeisms`** -- Claude-specific mannerisms: sycophantic openers, consent-theater phrasing, "important to note that" hedges. Derived from SLOP_Detector.
 - **`structural`** -- structural LLM tells: "not X but Y" negation pivots, sycophantic line openers, "in this section we'll" meta-commentary, "at the end of the day" closers. Original content.

--- a/builtin-packs/puffery.json
+++ b/builtin-packs/puffery.json
@@ -1,0 +1,19 @@
+{
+  "name": "pack:puffery",
+  "version": "0.1.0",
+  "description": "Promotional / editorializing puffery common in LLM prose: 'rich cultural heritage', 'nestled in the heart of', 'boasts', 'enduring legacy', 'leaves an indelible mark', and copula-avoidance flourishes. Original content -- regexes hand-authored, no third-party rule set incorporated.",
+  "phrases": [
+    { "pattern": "\\brich (cultural|literary|artistic|musical|architectural|natural|historical|spiritual) heritage\\b", "reason": "puffery" },
+    { "pattern": "\\b(stands|serves|stood|served) as a testament\\b", "reason": "puffery" },
+    { "pattern": "\\bleaves? an indelible mark\\b", "reason": "puffery" },
+    { "pattern": "\\bvaluable insights?\\b", "reason": "LLM filler" },
+    { "pattern": "\\bnestled (in|between|among|amid|along|within|atop|beside|deep)\\b", "reason": "travel-writing puffery" },
+    { "pattern": "\\benduring (legacy|appeal|charm|popularity|influence|presence|significance)\\b", "reason": "puffery" },
+    { "pattern": "\\bvibrant (community|culture|tapestry|atmosphere|scene|hub|ecosystem|nightlife|array|mix|blend)\\b", "reason": "puffery" },
+    { "pattern": "\\bboasts? (a|an|the|its|some|several|numerous|over|more than|impressive|stunning|an array|a range)\\b", "reason": "copula-avoidance puffery" },
+    { "pattern": "\\bdeeply rooted\\b", "reason": "puffery" },
+    { "pattern": "\\bsetting the stage for\\b", "reason": "LLM transition cliche" },
+    { "pattern": "\\b(a |an )?diverse array of\\b", "reason": "puffery" },
+    { "pattern": "\\bbreathtaking (views?|scenery|beauty|landscapes?|vistas?)\\b", "reason": "puffery" }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
             "enum": [
               "academic",
               "cliches",
+              "puffery",
               "fiction",
               "claudeisms",
               "structural",
@@ -89,6 +90,7 @@
             "enumDescriptions": [
               "Words over-represented in LLM-authored academic writing (derived from berenslab/llm-excess-vocab, MIT)",
               "General LLM cliche adjectives/nouns/verbs (derived from nanxstats/llm-cliches, MIT)",
+              "Promotional / editorializing puffery: 'rich cultural heritage', 'nestled in the heart of', 'boasts', 'enduring legacy', 'leaves an indelible mark', copula-avoidance flourishes. Original content.",
               "Fiction and creative-writing LLM tells, including NSFW markers (derived from SicariusSicariiStuff/SLOP_Detector, Apache-2.0)",
               "Claude-specific mannerisms and sycophantic consent-theater phrasing (derived from SicariusSicariiStuff/SLOP_Detector, Apache-2.0)",
               "Structural LLM tells: 'not X but Y', sycophantic openers, meta-commentary",

--- a/src/core/rules.ts
+++ b/src/core/rules.ts
@@ -2,7 +2,7 @@ import { CharRule, PhraseRule, RuleSet, Severity, SeverityOverride } from './typ
 
 export const LOCAL_RULES_FILENAME = '.llmsloprc.json';
 
-export const BUILTIN_PACKS = ['academic', 'cliches', 'fiction', 'claudeisms', 'structural', 'security', 'openai', 'gemini', 'deepseek', 'llama', 'qwen', 'grok'] as const;
+export const BUILTIN_PACKS = ['academic', 'cliches', 'puffery', 'fiction', 'claudeisms', 'structural', 'security', 'openai', 'gemini', 'deepseek', 'llama', 'qwen', 'grok'] as const;
 export type BuiltinPack = typeof BUILTIN_PACKS[number];
 
 type RawCharRule = {


### PR DESCRIPTION
Lower-priority follow-up to the 2026-05 rule review (#91).

**Stacked on #92** -- this branch is rebased on top of the `openai` pack branch, so the BUILTIN_PACKS / enum merge conflict is already resolved here. The base is set to `claude/openai-pack-and-invisibles-1TZkh` so this diff shows only the puffery changes. Once #92 merges, GitHub will auto-retarget this PR to `main` and it will merge cleanly. (If you'd rather land this first/independently, I can rebase it back onto `main`.)

## Change

New opt-in **`puffery`** pack (12 patterns) covering promotional / editorializing phrasing documented as an LLM tell:
`rich cultural heritage`, `nestled in the heart of`, `boasts`, `enduring legacy`, `leaves an indelible mark`, `deeply rooted`, `setting the stage for`, `diverse array of`, `valuable insights`, `breathtaking views`, `stands/serves as a testament`, `vibrant <community/culture/...>`.

Wired into `BUILTIN_PACKS`, the `package.json` `enabledPacks` enum + descriptions, and the README pack list (now thirteen packs, combined with #92's `openai`).

## Duplication avoidance

Every candidate was tested against the core list and existing packs before inclusion. Excluded because already covered:
- `showcase`, `bolster`, `garner`, `renowned` -- already in the `academic` pack.
- `in the realm of`, `plays a vital role`, `let's dive in`, `rich tapestry`, `a testament to` -- already caught by core regexes.

## False positives

Patterns are qualified (e.g. `vibrant` only before a noun like `community`/`culture`, `boasts` only before an article/quantifier) to keep noise low. Verified: an ordinary technical-prose sample produces **zero** findings; the intended puffery sample flags all expected phrases at `information` severity.

## Licensing

Original content -- regexes hand-authored to match commonly-observed promotional phrasing. No third-party rule set incorporated (in particular, not derived from the CC BY-SA Wikipedia list, to avoid a share-alike conflict with the repo's MIT license), so no `THIRD_PARTY_NOTICES.md` entry is required -- consistent with the other original-content packs.

https://claude.ai/code/session_01Sh3iPGayuCKMJBi4uaKX3m